### PR TITLE
Update parser tests for new schema field names

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -4,12 +4,13 @@ def test_s2_example():
     name = "S2B_MSIL2A_20241123T224759_N0511_R101_T03VUL_20241123T230829.SAFE"
     res = parse_auto(name)
     assert res is not None
-    assert res.fields["mission"] == "S2B"
-    assert res.fields["instrument_processing"] == "MSIL2A"
+    assert res.fields["platform"] == "S2B"
+    assert res.fields["processing_level"] == "MSIL2A"
 
 def test_s1_example():
     name = "S1A_IW_SLC__1SDV_20250105T053021_20250105T053048_A054321_D068F2E_ABC123.SAFE"
     res = parse_auto(name)
     assert res is not None
-    assert res.fields["mission"] == "S1A"
-    assert res.fields["instrument_mode"] == "IW"
+    assert res.fields["platform"] == "S1A"
+    assert res.fields["sar_instrument_mode"] == "IW"
+    assert res.fields["processing_level"] == "1SDV"


### PR DESCRIPTION
## Summary
- adjust parser tests for Sentinel-1 and Sentinel-2 schemas to use new field names (`platform`, `processing_level`, `sar_instrument_mode`)

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a966064d38832784e3860b158c3f5b