### PR TITLE
Adopt EUPL-1.2 license

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,4 +136,4 @@ parseo assemble \
 
 ## License
 
-EUPL-1.2 (see LICENSE file)
+This project is licensed under the [European Union Public Licence v1.2](LICENSE.txt).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "parseo"
 version = "0.2.0"  # or remove this and use setuptools-scm below
 description = "Filename parser/assembler for satellite data"
 readme = "README.md"
-license = { text = "MIT" }  # or {file = "LICENSE"}
+license = { text = "EUPL-1.2" }
 requires-python = ">=3.9"
 dependencies = [
   "jsonschema>=4,<5"
@@ -17,7 +17,7 @@ keywords = ["satellite", "remote-sensing", "filenames", "sentinel", "parsing"]
 classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: MIT License",
+  "License :: OSI Approved :: European Union Public Licence 1.2 (EUPL 1.2)",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
## Summary
- align project metadata with EUPL-1.2 license
- link README to the EUPL-1.2 LICENSE file

## Testing
- `PYTHONPATH=src pytest` *(fails: KeyError: 'mission')*


------
https://chatgpt.com/codex/tasks/task_e_68a963b4585c8327a3f99360c7c3e6b2