### PR TITLE
Remove pytest from runtime requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 fastapi
 uvicorn
-pytest


### PR DESCRIPTION
## Summary
- drop pytest from main requirements and rely on dev extras in `pyproject.toml`

## Testing
- `pip install -r requirements.txt`
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=69)*
- `PYTHONPATH=src pytest -q` *(fails: KeyError: 'mission')*

------
https://chatgpt.com/codex/tasks/task_e_68a965f98d5c83278142b6a99c2b460c