### PR TITLE
chore: move web deps to optional extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ parseo = "parseo.cli:main"
 # If you want optional extras:
 [project.optional-dependencies]
 dev = ["build", "twine", "ruff", "mypy", "pytest", "pytest-cov"]
+web = ["fastapi", "uvicorn"]
 
 [tool.setuptools]
 include-package-data = true  # ensure MANIFEST.in if you ship data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-fastapi
-uvicorn


### PR DESCRIPTION
## Summary
- drop FastAPI and Uvicorn from core requirements
- define optional `web` extra to install FastAPI and Uvicorn when needed

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a96cc0da688327bdbcb39a2e668312