### PR TITLE
docs: consolidate CLI examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,12 @@ print(res.fields)  # structured dict of extracted fields
 from parseo import assemble
 
 fields = {
-    "mission": "S2B",
-    "instrument_processing": "MSIL2A",
-    "sensing_datetime": "20241123T224759",
-    "processing_baseline": "N0511",
-    "relative_orbit": "R101",
-    "tile_id": "T03VUL",
+    "platform": "S2B",
+    "processing_level": "MSIL2A",
+    "datetime": "20241123T224759",
+    "version": "N0511",
+    "sat_relative_orbit": "R101",
+    "mgrs_tile": "T03VUL",
     "generation_datetime": "20241123T230829",
     "extension": ".SAFE"
 }
@@ -90,14 +90,7 @@ print(filename)
 
 ## Command Line Interface
 
-```bash
-# Parse a filename
-parseo parse S1A_IW_SLC__1SDV_20250105T053021_20250105T053048_A054321_D068F2E_ABC123.SAFE
-
-# List available schemas
-parseo list-schemas
-
-## Command Line Interface
+Use the CLI to parse filenames, list available schemas, and assemble filenames from fields.
 
 ```bash
 # Parse a filename
@@ -106,22 +99,21 @@ parseo parse S1A_IW_SLC__1SDV_20250105T053021_20250105T053048_A054321_D068F2E_AB
 # List available schemas
 parseo list-schemas
 
-# Assemble a filename from fields
-# The CLI auto-selects a schema based on the FIRST compulsory field declared by that schema.
+# Assemble a filename from fields.
+# The CLI auto-selects a schema based on the first compulsory field.
 
-# Example for a Sentinel-2 SAFE schema where the first field is 'mission'
+# Example: Sentinel-2 SAFE (first field: platform)
 parseo assemble \
-  mission=S2B instrument_processing=MSIL2A sensing_datetime=20241123T224759 \
-  processing_baseline=N0511 relative_orbit=R101 tile_id=T03VUL \
+  platform=S2B processing_level=MSIL2A datetime=20241123T224759 \
+  version=N0511 sat_relative_orbit=R101 mgrs_tile=T03VUL \
   generation_datetime=20241123T230829 extension=.SAFE
 # -> S2B_MSIL2A_20241123T224759_N0511_R101_T03VUL_20241123T230829.SAFE
 
-# Example for a CLMS HR-WSI product where the first field is 'prefix'
-# (first compulsory field name depends on the schema's fields_order[0])
+# Example: CLMS HR-WSI product (first field: prefix)
 parseo assemble \
-  prefix=CLMS_WSI product=WIC spatial_res=020m tile_id=T33WXP \
-  datetime=20201024T112121 platform=S2B version=V100 layer_code=WIC extension=.tif
-# -> CLMS_WSI_WIC_020m_T33WXP_20201024T112121_S2B_V100_WIC.tif
+  prefix=CLMS_WSI product=WIC pixel_spacing=020m tile_id=T33WXP \
+  sensing_datetime=20201024T103021 platform=S2B version=V100 file_id=WIC extension=.tif
+# -> CLMS_WSI_WIC_020m_T33WXP_20201024T103021_S2B_V100_WIC.tif
 ```
 
 ---


### PR DESCRIPTION
## Summary
- tidy README CLI section into a single heading
- update CLI and Python examples with current field names

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a96cc83dfc8327a814ced0be6d583c