### PR TITLE
Align Sentinel schemas with STAC 1.1

### DIFF
--- a/src/parseo/schemas/copernicus/sentinel/s3/s3_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s3/s3_filename_v1_0_0.json
@@ -1,118 +1,12 @@
 {
-    "$schema":  "https://json-schema.org/draft/2020-12/schema",
-    "title":  "Sentinel-3 filename",
-    "type":  "object",
-    "properties":  {
-                       "name":  {
-                                    "type":  "string"
-                                }
-                   },
-    "required":  [
-                     "name"
-                 ],
-    "x-parseo":  {
-                     "version":  "1.0.0",
-                     "parse_regex":  "^(?P\u003csatellite\u003eS3)(?P\u003cplatform\u003eA|B|C)_(?P\u003cinstrument\u003eOLCI|SLSTR|SRAL)_(?P\u003cprocessing_level\u003eL0|L1|L2)_(?P\u003csensing_datetime\u003e\\d{8}T\\d{6})(?:_(?P\u003ctrack\u003e\\d{3}))?(?:_(?P\u003csegment\u003e[A-Z0-9_\\-]{1,10}))?\\.(?P\u003cextension\u003e[A-Za-z0-9]+)$",
-                     "template":  "{satellite}{platform}_{instrument}_{processing_level}_{sensing_datetime}{track_opt}{segment_opt}.{extension}",
-                     "requirements":  {
-                                          "satellite":  {
-                                                            "$ref":  "fields.json#/$defs/satellite"
-                                                        },
-                                          "platform":  {
-                                                           "$ref":  "fields.json#/$defs/platform"
-                                                       },
-                                          "instrument":  {
-                                                             "$ref":  "fields.json#/$defs/instrument"
-                                                         },
-                                          "processing_level":  {
-                                                                   "$ref":  "fields.json#/$defs/processing_level"
-                                                               },
-                                          "sensing_datetime":  {
-                                                                   "$ref":  "fields.json#/$defs/sensing_datetime"
-                                                               },
-                                          "track":  {
-                                                        "$ref":  "fields.json#/$defs/track"
-                                                    },
-                                          "segment":  {
-                                                          "$ref":  "fields.json#/$defs/segment"
-                                                      },
-                                          "extension":  {
-                                                            "$ref":  "fields.json#/$defs/extension"
-                                                        }
-                                      },
-                     "build_transforms":  {
-                                              "platform":  [
-                                                               "upper"
-                                                           ],
-                                              "instrument":  [
-                                                                 "upper"
-                                                             ],
-                                              "processing_level":  [
-                                                                       "upper"
-                                                                   ],
-                                              "sensing_datetime":  [
-                                                                       "datetime:%Y%m%dT%H%M%S"
-                                                                   ],
-                                              "extension":  [
-                                                                "lower"
-                                                            ],
-                                              "_compose:track_opt":  [
-                                                                         "ifset:track:prefix:_"
-                                                                     ],
-                                              "_compose:segment_opt":  [
-                                                                           "ifset:segment:prefix:_"
-                                                                       ]
-                                          },
-                     "parse_transforms":  {
-                                              "extension":  [
-                                                                "lower"
-                                                            ]
-                                          },
-                     "fields":  {
-                                    "satellite":  {
-
-                                                  },
-                                    "platform":  {
-
-                                                 },
-                                    "instrument":  {
-
-                                                   },
-                                    "processing_level":  {
-
-                                                         },
-                                    "sensing_datetime":  {
-
-                                                         },
-                                    "track":  {
-
-                                              },
-                                    "segment":  {
-
-                                                },
-                                    "extension":  {
-
-                                                  }
-                                },
-                     "map_to_canonical":  {
-                                              "mission":  "{satellite}{platform}",
-                                              "instrument":  "{instrument}",
-                                              "level":  "{processing_level}",
-                                              "acq_datetime":  "{sensing_datetime}",
-                                              "track":  "{track}",
-                                              "segment":  "{segment}",
-                                              "extension":  "{extension}"
-                                          },
-                     "map_from_canonical":  {
-                                                "satellite":  "{mission[:2]}",
-                                                "platform":  "{mission[2:3]}",
-                                                "instrument":  "{instrument}",
-                                                "processing_level":  "{level}",
-                                                "sensing_datetime":  "{acq_datetime}",
-                                                "track":  "{track}",
-                                                "segment":  "{segment}",
-                                                "extension":  "{extension}"
-                                            },
-                     "valid_example":  "S3A_OLCI_L2_20250105T103021_080_SEG01.tif"
-                 }
+  "schema_id": "copernicus:sentinel:s3",
+  "schema_version": "1.0.0",
+  "stac_version": "1.1.0",
+  "stac_extensions": ["processing", "sat", "raster", "eo"],
+  "description": "Sentinel-3 product filename (OLCI/SLSTR/SRAL; optional track, segment, extension).",
+  "filename_pattern": "^(?P<platform>S3A|S3B|S3C)_(?P<instrument>OLCI|SLSTR|SRAL)_(?P<processing_level>L0|L1|L2)_(?P<datetime>\\d{8}T\\d{6})(?:_(?P<sat_relative_orbit>\\d{3}))?(?:_(?P<segment>[A-Z0-9_\\-]{1,10}))?(?P<extension>\\.[A-Za-z0-9]+)?$",
+  "examples": [
+    "S3A_OLCI_L2_20250105T103021_080_SEG01.tif",
+    "S3B_SRAL_L1_20230715T103021_123.nc"
+  ]
 }

--- a/src/parseo/schemas/copernicus/sentinel/s4/s4_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s4/s4_filename_v1_0_0.json
@@ -1,107 +1,12 @@
 {
-    "$schema":  "https://json-schema.org/draft/2020-12/schema",
-    "title":  "Sentinel-4 filename",
-    "type":  "object",
-    "properties":  {
-                       "name":  {
-                                    "type":  "string"
-                                }
-                   },
-    "required":  [
-                     "name"
-                 ],
-    "x-parseo":  {
-                     "version":  "1.0.0",
-                     "parse_regex":  "^(?P\u003csatellite\u003eS4)(?P\u003cplatform\u003eA|B)_(?P\u003cinstrument\u003eUVN)_(?P\u003cprocessing_level\u003eL1|L2)_(?P\u003csensing_datetime\u003e\\d{8}T\\d{6})(?:_(?P\u003ctile\u003e[A-Z0-9_\\-]{3,10}))?\\.(?P\u003cextension\u003e[A-Za-z0-9]+)$",
-                     "template":  "{satellite}{platform}_{instrument}_{processing_level}_{sensing_datetime}{tile_opt}.{extension}",
-                     "requirements":  {
-                                          "satellite":  {
-                                                            "$ref":  "fields.json#/$defs/satellite"
-                                                        },
-                                          "platform":  {
-                                                           "$ref":  "fields.json#/$defs/platform"
-                                                       },
-                                          "instrument":  {
-                                                             "$ref":  "fields.json#/$defs/instrument"
-                                                         },
-                                          "processing_level":  {
-                                                                   "$ref":  "fields.json#/$defs/processing_level"
-                                                               },
-                                          "sensing_datetime":  {
-                                                                   "$ref":  "fields.json#/$defs/sensing_datetime"
-                                                               },
-                                          "tile":  {
-                                                       "$ref":  "fields.json#/$defs/tile"
-                                                   },
-                                          "extension":  {
-                                                            "$ref":  "fields.json#/$defs/extension"
-                                                        }
-                                      },
-                     "build_transforms":  {
-                                              "platform":  [
-                                                               "upper"
-                                                           ],
-                                              "instrument":  [
-                                                                 "upper"
-                                                             ],
-                                              "processing_level":  [
-                                                                       "upper"
-                                                                   ],
-                                              "sensing_datetime":  [
-                                                                       "datetime:%Y%m%dT%H%M%S"
-                                                                   ],
-                                              "extension":  [
-                                                                "lower"
-                                                            ],
-                                              "_compose:tile_opt":  [
-                                                                        "ifset:tile:prefix:_"
-                                                                    ]
-                                          },
-                     "parse_transforms":  {
-                                              "extension":  [
-                                                                "lower"
-                                                            ]
-                                          },
-                     "fields":  {
-                                    "satellite":  {
-
-                                                  },
-                                    "platform":  {
-
-                                                 },
-                                    "instrument":  {
-
-                                                   },
-                                    "processing_level":  {
-
-                                                         },
-                                    "sensing_datetime":  {
-
-                                                         },
-                                    "tile":  {
-
-                                             },
-                                    "extension":  {
-
-                                                  }
-                                },
-                     "map_to_canonical":  {
-                                              "mission":  "{satellite}{platform}",
-                                              "instrument":  "{instrument}",
-                                              "level":  "{processing_level}",
-                                              "acq_datetime":  "{sensing_datetime}",
-                                              "tile":  "{tile}",
-                                              "extension":  "{extension}"
-                                          },
-                     "map_from_canonical":  {
-                                                "satellite":  "{mission[:2]}",
-                                                "platform":  "{mission[2:3]}",
-                                                "instrument":  "{instrument}",
-                                                "processing_level":  "{level}",
-                                                "sensing_datetime":  "{acq_datetime}",
-                                                "tile":  "{tile}",
-                                                "extension":  "{extension}"
-                                            },
-                     "valid_example":  "S4A_UVN_L2_20250105T103021_EUROPE.tif"
-                 }
+  "schema_id": "copernicus:sentinel:s4",
+  "schema_version": "1.0.0",
+  "stac_version": "1.1.0",
+  "stac_extensions": ["processing", "sat", "raster", "eo"],
+  "description": "Sentinel-4 product filename (UVN; optional tile, extension).",
+  "filename_pattern": "^(?P<platform>S4A|S4B)_(?P<instrument>UVN)_(?P<processing_level>L1|L2)_(?P<datetime>\\d{8}T\\d{6})(?:_(?P<tile>[A-Z0-9_\\-]{3,10}))?(?P<extension>\\.[A-Za-z0-9]+)?$",
+  "examples": [
+    "S4A_UVN_L2_20250105T103021_EUROPE.tif",
+    "S4B_UVN_L1_20240701T101010.nc"
+  ]
 }

--- a/src/parseo/schemas/copernicus/sentinel/s5p/s5p_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s5p/s5p_filename_v1_0_0.json
@@ -1,101 +1,12 @@
 {
-    "$schema":  "https://json-schema.org/draft/2020-12/schema",
-    "title":  "Sentinel-5P filename",
-    "type":  "object",
-    "properties":  {
-                       "name":  {
-                                    "type":  "string"
-                                }
-                   },
-    "required":  [
-                     "name"
-                 ],
-    "x-parseo":  {
-                     "version":  "1.0.0",
-                     "parse_regex":  "^(?P\u003csatellite\u003eS5P)(?P\u003cplatform\u003eP)_(?P\u003cinstrument\u003eTROPOMI)_(?P\u003cprocessing_level\u003eL1B|L2)_(?P\u003cproduct_type\u003e[A-Z0-9_]{2,12})_(?P\u003csensing_datetime\u003e\\d{8}T\\d{6})\\.(?P\u003cextension\u003e[A-Za-z0-9]+)$",
-                     "template":  "{satellite}{platform}_{instrument}_{processing_level}_{product_type}_{sensing_datetime}.{extension}",
-                     "requirements":  {
-                                          "satellite":  {
-                                                            "$ref":  "fields.json#/$defs/satellite"
-                                                        },
-                                          "platform":  {
-                                                           "$ref":  "fields.json#/$defs/platform"
-                                                       },
-                                          "instrument":  {
-                                                             "$ref":  "fields.json#/$defs/instrument"
-                                                         },
-                                          "processing_level":  {
-                                                                   "$ref":  "fields.json#/$defs/processing_level"
-                                                               },
-                                          "product_type":  {
-                                                               "$ref":  "fields.json#/$defs/product_type"
-                                                           },
-                                          "sensing_datetime":  {
-                                                                   "$ref":  "fields.json#/$defs/sensing_datetime"
-                                                               },
-                                          "extension":  {
-                                                            "$ref":  "fields.json#/$defs/extension"
-                                                        }
-                                      },
-                     "build_transforms":  {
-                                              "processing_level":  [
-                                                                       "upper"
-                                                                   ],
-                                              "product_type":  [
-                                                                   "upper"
-                                                               ],
-                                              "sensing_datetime":  [
-                                                                       "datetime:%Y%m%dT%H%M%S"
-                                                                   ],
-                                              "extension":  [
-                                                                "lower"
-                                                            ]
-                                          },
-                     "parse_transforms":  {
-                                              "extension":  [
-                                                                "lower"
-                                                            ]
-                                          },
-                     "fields":  {
-                                    "satellite":  {
-
-                                                  },
-                                    "platform":  {
-
-                                                 },
-                                    "instrument":  {
-
-                                                   },
-                                    "processing_level":  {
-
-                                                         },
-                                    "product_type":  {
-
-                                                     },
-                                    "sensing_datetime":  {
-
-                                                         },
-                                    "extension":  {
-
-                                                  }
-                                },
-                     "map_to_canonical":  {
-                                              "mission":  "{satellite}{platform}",
-                                              "instrument":  "{instrument}",
-                                              "level":  "{processing_level}",
-                                              "product_type":  "{product_type}",
-                                              "acq_datetime":  "{sensing_datetime}",
-                                              "extension":  "{extension}"
-                                          },
-                     "map_from_canonical":  {
-                                                "satellite":  "{mission[:-1]}",
-                                                "platform":  "{mission[-1:]}",
-                                                "instrument":  "{instrument}",
-                                                "processing_level":  "{level}",
-                                                "product_type":  "{product_type}",
-                                                "sensing_datetime":  "{acq_datetime}",
-                                                "extension":  "{extension}"
-                                            },
-                     "valid_example":  "S5PP_TROPOMI_L2_NO2_20250105T103021.nc"
-                 }
+  "schema_id": "copernicus:sentinel:s5p",
+  "schema_version": "1.0.0",
+  "stac_version": "1.1.0",
+  "stac_extensions": ["processing", "sat", "raster", "eo"],
+  "description": "Sentinel-5P product filename (TROPOMI; extension optional).",
+  "filename_pattern": "^(?P<platform>S5P)_(?P<instrument>TROPOMI)_(?P<processing_level>L1B|L2)_(?P<product_type>[A-Z0-9_]{2,12})_(?P<datetime>\\d{8}T\\d{6})(?P<extension>\\.[A-Za-z0-9]+)?$",
+  "examples": [
+    "S5P_TROPOMI_L2_NO2_20250105T103021.nc",
+    "S5P_TROPOMI_L1B_RA_BD3_20230715T103021.he5"
+  ]
 }

--- a/src/parseo/schemas/copernicus/sentinel/s6/s6_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s6/s6_filename_v1_0_0.json
@@ -1,102 +1,12 @@
 {
-    "$schema":  "https://json-schema.org/draft/2020-12/schema",
-    "title":  "Sentinel-6 filename",
-    "type":  "object",
-    "properties":  {
-                       "name":  {
-                                    "type":  "string"
-                                }
-                   },
-    "required":  [
-                     "name"
-                 ],
-    "x-parseo":  {
-                     "version":  "1.0.0",
-                     "parse_regex":  "^(?P\u003csatellite\u003eS6)(?P\u003cplatform\u003eA|B)_(?P\u003cinstrument\u003eP4)_(?P\u003csampling_rate\u003e1Hz|2Hz|20Hz)(?P\u003cmode\u003e[A-Z])_(?P\u003cstart_datetime\u003e\\d{8}T\\d{6})_(?P\u003cstop_datetime\u003e\\d{8}T\\d{6})_(?P\u003csegment\u003e\\d{4})\\.(?P\u003cextension\u003e[A-Za-z0-9]+)$",
-                     "template":  "{satellite}{platform}_{instrument}_{sampling_rate}{mode}_{start_datetime}_{stop_datetime}_{segment}.{extension}",
-                     "requirements":  {
-                                          "satellite":  {
-                                                            "$ref":  "fields.json#/$defs/satellite"
-                                                        },
-                                          "platform":  {
-                                                           "$ref":  "fields.json#/$defs/platform"
-                                                       },
-                                          "instrument":  {
-                                                             "$ref":  "fields.json#/$defs/instrument"
-                                                         },
-                                          "sampling_rate":  {
-                                                                "$ref":  "fields.json#/$defs/sampling_rate"
-                                                            },
-                                          "mode":  {
-                                                       "$ref":  "fields.json#/$defs/mode"
-                                                   },
-                                          "start_datetime":  {
-                                                                 "$ref":  "fields.json#/$defs/datetime_compact"
-                                                             },
-                                          "stop_datetime":  {
-                                                                "$ref":  "fields.json#/$defs/datetime_compact"
-                                                            },
-                                          "segment":  {
-                                                          "$ref":  "fields.json#/$defs/segment"
-                                                      },
-                                          "extension":  {
-                                                            "$ref":  "fields.json#/$defs/extension"
-                                                        }
-                                      },
-                     "build_transforms":  {
-                                              "platform":  [
-                                                               "upper"
-                                                           ],
-                                              "sampling_rate":  [
-                                                                    "upper"
-                                                                ],
-                                              "mode":  [
-                                                           "upper"
-                                                       ],
-                                              "start_datetime":  [
-                                                                     "datetime:%Y%m%dT%H%M%S"
-                                                                 ],
-                                              "stop_datetime":  [
-                                                                    "datetime:%Y%m%dT%H%M%S"
-                                                                ],
-                                              "extension":  [
-                                                                "lower"
-                                                            ]
-                                          },
-                     "parse_transforms":  {
-                                              "extension":  [
-                                                                "lower"
-                                                            ]
-                                          },
-                     "fields":  {
-                                    "satellite":  {
-
-                                                  },
-                                    "platform":  {
-
-                                                 },
-                                    "instrument":  {
-
-                                                   },
-                                    "sampling_rate":  {
-
-                                                      },
-                                    "mode":  {
-
-                                             },
-                                    "start_datetime":  {
-
-                                                       },
-                                    "stop_datetime":  {
-
-                                                      },
-                                    "segment":  {
-
-                                                },
-                                    "extension":  {
-
-                                                  }
-                                },
-                     "valid_example":  "S6A_P4_20HzN_20221015T103529_20221015T112143_0001.nc"
-                 }
+  "schema_id": "copernicus:sentinel:s6",
+  "schema_version": "1.0.0",
+  "stac_version": "1.1.0",
+  "stac_extensions": ["processing", "sat"],
+  "description": "Sentinel-6 product filename (P4 altimetry; extension optional).",
+  "filename_pattern": "^(?P<platform>S6A|S6B)_(?P<instrument>P4)_(?P<sampling_rate>1Hz|2Hz|20Hz)(?P<mode>[A-Z])_(?P<start_datetime>\\d{8}T\\d{6})_(?P<end_datetime>\\d{8}T\\d{6})_(?P<segment>\\d{4})(?P<extension>\\.[A-Za-z0-9]+)?$",
+  "examples": [
+    "S6A_P4_20HzN_20221015T103529_20221015T112143_0001.nc",
+    "S6B_P4_1HzN_20230715T103021_20230715T103121_0002"
+  ]
 }


### PR DESCRIPTION
## Summary
- Simplify Sentinel-3 schema to match Sentinel-1/2 style and adopt STAC 1.1 conventions
- Convert Sentinel-4 and Sentinel-5P schema JSONs to STAC 1.1 format
- Update Sentinel-6 filename schema with STAC 1.1 fields and regex

## Testing
- ⚠️ `pip install -e .` *(proxy prevented dependency download)*
- ✅ `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a96cb3bd8c83279179d900184d0111