### PR TITLE
Expose assemble in package init and remove BOM

### DIFF
--- a/src/parseo/__init__.py
+++ b/src/parseo/__init__.py
@@ -1,3 +1,4 @@
-﻿from .parser import parse_auto
+from .parser import parse_auto
+from .assembler import assemble
 
-__all__ = ["parse_auto", "parser"]  # include parser too if you still want it visible
+__all__ = ["parse_auto", "assemble"]


### PR DESCRIPTION
## Summary
- remove UTF-8 BOM from parseo package init
- expose `assemble` alongside `parse_auto`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'parseo')*

------
https://chatgpt.com/codex/tasks/task_e_68a966087aec8327a44918022d341500