### PR TITLE
Clarify assembler dependency for CLI assemble command

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ print(filename)
 ## Command Line Interface
 
 Use the CLI to parse filenames, list available schemas, and assemble filenames from fields.
+The `assemble` subcommand relies on the `parseo.assembler` module, which ships with the
+standard parseo installation. If you run `parseo assemble` in an environment where this
+module was intentionally omitted, the CLI will exit with:
+
+```
+The 'assemble' command requires parseo.assembler, which is part of the standard parseo installation.
+```
+
+Reinstall parseo with assembler support or provide your own `parseo/assembler.py`
+implementing `assemble(schema_path, fields)` to enable this command.
 
 ```bash
 # Parse a filename

--- a/src/parseo/cli.py
+++ b/src/parseo/cli.py
@@ -199,9 +199,11 @@ def main(argv: List[str] | None = None) -> int:
             from parseo.assembler import assemble as assemble_with_schema
         except ModuleNotFoundError:
             raise SystemExit(
-                "The 'assemble' command requires parseo.assembler.\n"
-                "Add 'src/parseo/assembler.py' with an 'assemble(schema_path, fields)' function, "
-                "or use 'parse'/'list-schemas' for now."
+                "The 'assemble' command requires parseo.assembler, which is part of the "
+                "standard parseo installation.\n"
+                "If it is missing, reinstall parseo with assembler support or provide a "
+                "'parseo/assembler.py' implementing 'assemble(schema_path, fields)'. "
+                "You can still use 'parse' or 'list-schemas'."
             )
 
         fields = _resolve_fields(args)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 
-import json, re, pathlib
+import json, re, pathlib, sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "src"))
 
 def load_schema_by_name(root_dir: str, fname: str):
     root = pathlib.Path(root_dir)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,56 @@
+import sys
+import builtins
+import pytest
+
+from parseo import cli
+
+
+def test_cli_assemble_success(capsys):
+    sys.argv = [
+        "parseo",
+        "assemble",
+        "prefix=CLMS_WSI",
+        "product=WIC",
+        "pixel_spacing=020m",
+        "tile_id=T33WXP",
+        "sensing_datetime=20201024T103021",
+        "platform=S2B",
+        "version=V100",
+        "file_id=WIC",
+        "extension=.tif",
+    ]
+    assert cli.main() == 0
+    captured = capsys.readouterr()
+    assert (
+        captured.out.strip()
+        == "CLMS_WSI_WIC_020m_T33WXP_20201024T103021_S2B_V100_WIC_.tif"
+    )
+
+
+def test_cli_assemble_missing_assembler(monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "parseo.assembler":
+            raise ModuleNotFoundError
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    sys.argv = [
+        "parseo",
+        "assemble",
+        "prefix=CLMS_WSI",
+        "product=WIC",
+        "pixel_spacing=020m",
+        "tile_id=T33WXP",
+        "sensing_datetime=20201024T103021",
+        "platform=S2B",
+        "version=V100",
+        "file_id=WIC",
+        "extension=.tif",
+    ]
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    msg = str(exc.value)
+    assert "requires parseo.assembler" in msg
+    assert "standard parseo installation" in msg


### PR DESCRIPTION
## Summary
- clarify lazy-import error message that assembler is part of standard install
- document assembler requirement and fallback instructions in README
- add CLI tests for successful assembly and missing assembler message

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a96f042e8c8327b2f449ffa93c86e4