### PR TITLE
Expose assemble in parseo package

### DIFF
--- a/src/parseo/__init__.py
+++ b/src/parseo/__init__.py
@@ -1,3 +1,4 @@
 from .parser import parse_auto
+from .assembler import assemble
 
-__all__ = ["parse_auto", "parser"]  # include parser too if you still want it visible
+__all__ = ["parse_auto", "assemble", "parser"]  # include parser too if you still want it visible

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from parseo import assemble
+
+
+def test_assemble_clms_fsc_schema():
+    schema = Path(__file__).resolve().parents[1] / "src/parseo/schemas/copernicus/clms/hr-wsi/fsc_filename_structure.json"
+    fields = {
+        "prefix": "CLMS_WSI",
+        "product": "FSC",
+        "pixel_spacing": "020m",
+        "tile_id": "T32TNS",
+        "sensing_datetime": "20211018T103021",
+        "platform": "S2A",
+        "version": "V100",
+        "file_id": "FSCOG",
+        "extension": ".tif",
+    }
+    result = assemble(schema, fields)
+    assert result == "CLMS_WSI_FSC_020m_T32TNS_20211018T103021_S2A_V100_FSCOG_.tif"


### PR DESCRIPTION
## Summary
- import `assemble` in package namespace and expose via `__all__`
- add test ensuring `assemble` works with CLMS FSC schema

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a96f0fc8408327a2c6840646d0c441