### PR TITLE
Expose parser submodule in package namespace

### DIFF
--- a/src/parseo/__init__.py
+++ b/src/parseo/__init__.py
@@ -1,4 +1,11 @@
 from .parser import parse_auto
 from .assembler import assemble
 
-__all__ = ["parse_auto", "assemble", "parser"]  # include parser too if you still want it visible
+__all__ = ["parse_auto", "assemble"]
+
+try:  # pragma: no cover - import failure handled for graceful degradation
+    from . import parser  # noqa: F401  # import for side effect and re-export
+except Exception:  # ImportError and others
+    pass
+else:
+    __all__.append("parser")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,7 @@
+def test_star_import_exposes_parser():
+    import parseo
+
+    ns = {}
+    exec("from parseo import *", ns)
+
+    assert ns["parser"] is parseo.parser


### PR DESCRIPTION
## Summary
- expose `parser` module when importing `parseo`
- add tests for star-import behavior

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a976d365e48327b7ab72ea7750eb35