### PR TITLE
Handle JSON parsing errors for CLI fields

### DIFF
--- a/src/parseo/cli.py
+++ b/src/parseo/cli.py
@@ -134,9 +134,15 @@ def _resolve_fields(args) -> Dict[str, Any]:
             raw = _stdin_text()
             if not raw.strip():
                 raise SystemExit("--fields-json '-' set but stdin is empty.")
-            return json.loads(raw)
+            try:
+                return json.loads(raw)
+            except json.JSONDecodeError as e:
+                raise SystemExit(f"--fields-json '-' is not valid JSON: {e}")
         else:
-            return json.loads(args.fields_json)
+            try:
+                return json.loads(args.fields_json)
+            except json.JSONDecodeError as e:
+                raise SystemExit(f"--fields-json is not valid JSON: {e}")
 
     # 2) stdin JSON (only if no positional fields were given)
     if not args.fields:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 import sys
 import builtins
+import io
 import pytest
 
 from parseo import cli
@@ -54,3 +55,18 @@ def test_cli_assemble_missing_assembler(monkeypatch):
     msg = str(exc.value)
     assert "requires parseo.assembler" in msg
     assert "standard parseo installation" in msg
+
+
+def test_fields_json_invalid_string():
+    sys.argv = ["parseo", "assemble", "--fields-json", "{"]
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert "--fields-json is not valid JSON" in str(exc.value)
+
+
+def test_fields_json_invalid_stdin(monkeypatch):
+    sys.argv = ["parseo", "assemble", "--fields-json", "-"]
+    monkeypatch.setattr(sys, "stdin", io.StringIO("{"))
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+    assert "--fields-json '-' is not valid JSON" in str(exc.value)


### PR DESCRIPTION
## Summary
- add robust JSON parsing for `--fields-json` and stdin options
- extend CLI tests for invalid JSON inputs

## Testing
- `pre-commit run --files src/parseo/cli.py tests/test_cli.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a977b229948327a68cb7f80264b24f