### PR TITLE
Align Sentinel-1 filename schema with field definitions

### DIFF
--- a/src/parseo/schemas/copernicus/sentinel/s1/s1_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s1/s1_filename_v1_0_0.json
@@ -3,11 +3,11 @@
   "schema_version": "1.0.0",
   "stac_version": "1.1.0",
   "stac_extensions": ["processing", "sat", "sar"],
-  "description": "Sentinel-1 SAFE product filename; TTTR token is SLC_ or GRD(F|H|M); extension optional.",
-  "filename_pattern": "^(?P<platform>S1A|S1B|S1C)_(?P<sar_instrument_mode>IW|SM|EW|WV)_(?P<sar_product_type>SLC_|GRDF|GRDH|GRDM|OCN)_(?P<processing_level>[0-9A-Z]{3,4})_(?P<start_datetime>\\d{8}T\\d{6})_(?P<end_datetime>\\d{8}T\\d{6})_(?P<sat_absolute_orbit>A\\d{6})_(?P<mission_data_take_id>D[0-9A-F]{6})_(?P<product_id>[0-9A-Z]{6})(?P<extension>\\.SAFE)?$",
+  "description": "Sentinel-1 SAFE product filename; TTTR token is SLC_, OCN_, or GRD(F|H|M); extension optional.",
+  "filename_pattern": "^(?P<platform>S1A|S1B|S1C)_(?P<mode>IW|SM|EW|WV)_(?P<product>SLC_|OCN_|GRDF|GRDH|GRDM)_(?P<level>\\d[A-Z]{2})(?P<pol>VV|HH|VH|HV)_(?P<start_datetime>\\d{8}T\\d{6})_(?P<end_datetime>\\d{8}T\\d{6})_(?P<abs_orbit>A\\d{6})_(?P<datatake>D[0-9A-F]{6,7})_(?P<product_id>[0-9A-F]{4,12})(?P<extension>\\.SAFE)?$",
   "examples": [
-    "S1A_IW_SLC__1SDV_20250105T053021_20250105T053048_A054321_D068F2E_ABC123.SAFE",
-    "S1B_EW_GRDH_1SSH_20190101T000000_20190101T000030_A012345_D0ABCDE_ABCDEF",
-    "S1C_SM_OCN_1SSS_20240701T101010_20240701T101111_A123456_D1A2B3C_1A2B3C.SAFE"
+    "S1A_IW_SLC__1SDVV_20250105T053021_20250105T053048_A054321_D068F2E_ABC123.SAFE",
+    "S1B_EW_GRDH_1SHHH_20190101T000000_20190101T000030_A012345_D0ABCDE_ABCDEF",
+    "S1C_SM_OCN__1SVHV_20240701T101010_20240701T101111_A123456_D1A2B3C_1A2B3C.SAFE"
   ]
 }

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -10,12 +10,14 @@ def test_s2_example():
     assert res.fields["processing_level"] == "MSIL2A"
 
 def test_s1_example():
-    name = "S1A_IW_SLC__1SDV_20250105T053021_20250105T053048_A054321_D068F2E_ABC123.SAFE"
+    name = "S1A_IW_SLC__1SDVV_20250105T053021_20250105T053048_A054321_D068F2E_ABC123.SAFE"
     res = parse_auto(name)
     assert res is not None
     assert res.fields["platform"] == "S1A"
-    assert res.fields["sar_instrument_mode"] == "IW"
-    assert res.fields["processing_level"] == "1SDV"
+    assert res.fields["mode"] == "IW"
+    assert res.fields["product"] == "SLC_"
+    assert res.fields["level"] == "1SD"
+    assert res.fields["pol"] == "VV"
 
 
 def test_schema_paths_cached(monkeypatch):
@@ -32,7 +34,7 @@ def test_schema_paths_cached(monkeypatch):
 
     # Two parses should trigger only a single scan of schema files
     parser.parse_auto("S2B_MSIL2A_20241123T224759_N0511_R101_T03VUL_20241123T230829.SAFE")
-    parser.parse_auto("S1A_IW_SLC__1SDV_20250105T053021_20250105T053048_A054321_D068F2E_ABC123.SAFE")
+    parser.parse_auto("S1A_IW_SLC__1SDVV_20250105T053021_20250105T053048_A054321_D068F2E_ABC123.SAFE")
 
     assert calls["n"] == 1
 


### PR DESCRIPTION
## Summary
- Align Sentinel-1 filename regex group names with field definitions
- Support official 4-char product tokens and full datatake/product ID lengths
- Add polarization group and update tests

## Testing
- `pytest -q`
- `pre-commit run --files src/parseo/schemas/copernicus/sentinel/s1/s1_filename_v1_0_0.json tests/test_parser.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a97a35342c832785f1801ab9ce353e