### PR TITLE
Align Sentinel-2 schema fields with STAC naming

### DIFF
--- a/src/parseo/schemas/copernicus/sentinel/s2/fields.json
+++ b/src/parseo/schemas/copernicus/sentinel/s2/fields.json
@@ -30,16 +30,6 @@
                                               ],
                                    "description":  "Spacecraft unit"
                                },
-                  "instrument":  {
-                                     "type":  "string",
-                                     "values":  [
-                                                    {
-                                                        "code":  "MSI",
-                                                        "label":  "Multispectral Instrument"
-                                                    }
-                                                ],
-                                     "description":  "Instrument identifier"
-                                 },
                   "processing_level":  {
                                            "type":  "string",
                                            "values":  [

--- a/src/parseo/schemas/copernicus/sentinel/s2/s2_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s2/s2_filename_v1_0_0.json
@@ -4,7 +4,7 @@
   "stac_version": "1.1.0",
   "stac_extensions": ["processing", "sat", "raster", "eo", "mgrs"],
   "description": "Sentinel-2 SAFE product filename (MSIL1C/MSIL2A; extension optional).",
-  "filename_pattern": "^(?P<platform>S2A|S2B|S2C)_(?P<processing_level>MSIL1C|MSIL2A)_(?P<datetime>\\d{8}T\\d{6})_(?P<version>N\\d{4})_(?P<sat_relative_orbit>R\\d{3})_(?P<mgrs_tile>T[0-9A-Z]{5})_(?P<generation_datetime>\\d{8}T\\d{6})(?P<extension>\\.SAFE)?$",
+  "filename_pattern": "^(?P<platform>S2A|S2B|S2C)_(?P<processing_level>MSIL1C|MSIL2A)_(?P<sensing_datetime>\\d{8}T\\d{6})_(?P<processing_baseline>N\\d{4})_(?P<relative_orbit>R\\d{3})_(?P<mgrs_tile>T[0-9A-Z]{5})_(?P<generation_datetime>\\d{8}T\\d{6})(?P<extension>\\.SAFE)?$",
   "examples": [
     "S2B_MSIL2A_20241123T224759_N0511_R101_T03VUL_20241123T230829.SAFE",
     "S2A_MSIL1C_20230715T103021_N0400_R052_T32TNS_20230715T103555"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -8,6 +8,9 @@ def test_s2_example():
     assert res is not None
     assert res.fields["platform"] == "S2B"
     assert res.fields["processing_level"] == "MSIL2A"
+    assert res.fields["sensing_datetime"] == "20241123T224759"
+    assert res.fields["processing_baseline"] == "N0511"
+    assert res.fields["relative_orbit"] == "R101"
 
 def test_s1_example():
     name = "S1A_IW_SLC__1SDV_20250105T053021_20250105T053048_A054321_D068F2E_ABC123.SAFE"


### PR DESCRIPTION
## Summary
- Align Sentinel-2 filename regex with field names (`sensing_datetime`, `processing_baseline`, `relative_orbit`)
- Drop unused instrument field from Sentinel-2 field definitions
- Extend tests to assert parsing of new Sentinel-2 fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a97a574dd083278fe2812173035968