### PR TITLE
Harmonise Sentinel schema structures

### DIFF
--- a/src/parseo/schemas/copernicus/sentinel/s3/fields.json
+++ b/src/parseo/schemas/copernicus/sentinel/s3/fields.json
@@ -1,90 +1,90 @@
 {
-    "$schema":  "https://json-schema.org/draft/2020-12/schema",
-    "title":  "Sentinel-3 Fields",
-    "$defs":  {
-                  "satellite":  {
-                                    "type":  "string",
-                                    "values":  [
-                                                   {
-                                                       "code":  "S3",
-                                                       "label":  "Sentinel-3 mission"
-                                                   }
-                                               ],
-                                    "description":  "Mission family"
-                                },
-                  "platform":  {
-                                   "type":  "string",
-                                   "values":  [
-                                                  {
-                                                      "code":  "A",
-                                                      "label":  "Unit A"
-                                                  },
-                                                  {
-                                                      "code":  "B",
-                                                      "label":  "Unit B"
-                                                  },
-                                                  {
-                                                      "code":  "C",
-                                                      "label":  "Unit C"
-                                                  }
-                                              ],
-                                   "description":  "Spacecraft unit"
-                               },
-                  "instrument":  {
-                                     "type":  "string",
-                                     "values":  [
-                                                    {
-                                                        "code":  "OLCI",
-                                                        "label":  "Ocean and Land Colour Instrument"
-                                                    },
-                                                    {
-                                                        "code":  "SLSTR",
-                                                        "label":  "Sea and Land Surface Temperature Radiometer"
-                                                    },
-                                                    {
-                                                        "code":  "SRAL",
-                                                        "label":  "SAR Radar Altimeter"
-                                                    }
-                                                ],
-                                     "description":  "Instrument identifier"
-                                 },
-                  "processing_level":  {
-                                           "type":  "string",
-                                           "values":  [
-                                                          {
-                                                              "code":  "L0",
-                                                              "label":  "Level-0"
-                                                          },
-                                                          {
-                                                              "code":  "L1",
-                                                              "label":  "Level-1"
-                                                          },
-                                                          {
-                                                              "code":  "L2",
-                                                              "label":  "Level-2"
-                                                          }
-                                                      ],
-                                           "description":  "Processing level (coarse categories)"
-                                       },
-                  "sensing_datetime":  {
-                                           "type":  "string",
-                                           "pattern":  "^\\d{8}T\\d{6}$",
-                                           "description":  "Acquisition datetime (UTC, YYYYMMDDTHHMMSS)"
-                                       },
-                  "track":  {
-                                "type":  "string",
-                                "pattern":  "^[0-9]{3}$",
-                                "description":  "Optional track/orbit-like number (3 digits)"
-                            },
-                  "segment":  {
-                                  "type":  "string",
-                                  "pattern":  "^[A-Z0-9_\\-]{1,10}$",
-                                  "description":  "Optional segment or product discriminator"
-                              },
-                  "extension":  {
-                                    "type":  "string",
-                                    "pattern":  "^[A-Za-z0-9]+$",
-                                    "description":  "File extension without leading dot"
-                                }
-              }
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Sentinel-3 Fields",
+    "$defs": {
+        "satellite": {
+            "type": "string",
+            "values": [
+                {
+                    "code": "S3",
+                    "label": "Sentinel-3 mission"
+                }
+            ],
+            "description": "Mission family"
+        },
+        "platform": {
+            "type": "string",
+            "values": [
+                {
+                    "code": "A",
+                    "label": "Unit A"
+                },
+                {
+                    "code": "B",
+                    "label": "Unit B"
+                },
+                {
+                    "code": "C",
+                    "label": "Unit C"
+                }
+            ],
+            "description": "Spacecraft unit"
+        },
+        "instrument": {
+            "type": "string",
+            "values": [
+                {
+                    "code": "OLCI",
+                    "label": "Ocean and Land Colour Instrument"
+                },
+                {
+                    "code": "SLSTR",
+                    "label": "Sea and Land Surface Temperature Radiometer"
+                },
+                {
+                    "code": "SRAL",
+                    "label": "SAR Radar Altimeter"
+                }
+            ],
+            "description": "Instrument identifier"
+        },
+        "processing_level": {
+            "type": "string",
+            "values": [
+                {
+                    "code": "L0",
+                    "label": "Level-0"
+                },
+                {
+                    "code": "L1",
+                    "label": "Level-1"
+                },
+                {
+                    "code": "L2",
+                    "label": "Level-2"
+                }
+            ],
+            "description": "Processing level (coarse categories)"
+        },
+        "sensing_datetime": {
+            "type": "string",
+            "pattern": "^\\d{8}T\\d{6}$",
+            "description": "Acquisition datetime (UTC, YYYYMMDDTHHMMSS)"
+        },
+        "relative_orbit": {
+            "type": "string",
+            "pattern": "^\\d{3}$",
+            "description": "Relative orbit number (3 digits; optional)"
+        },
+        "segment": {
+            "type": "string",
+            "pattern": "^[A-Z0-9_\\-]{1,10}$",
+            "description": "Optional segment or product discriminator"
+        },
+        "extension": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9]+$",
+            "description": "File extension without leading dot"
+        }
+    }
 }

--- a/src/parseo/schemas/copernicus/sentinel/s3/s3_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s3/s3_filename_v1_0_0.json
@@ -3,8 +3,8 @@
   "schema_version": "1.0.0",
   "stac_version": "1.1.0",
   "stac_extensions": ["processing", "sat", "raster", "eo"],
-  "description": "Sentinel-3 product filename (OLCI/SLSTR/SRAL; optional track, segment, extension).",
-  "filename_pattern": "^(?P<platform>S3A|S3B|S3C)_(?P<instrument>OLCI|SLSTR|SRAL)_(?P<processing_level>L0|L1|L2)_(?P<datetime>\\d{8}T\\d{6})(?:_(?P<sat_relative_orbit>\\d{3}))?(?:_(?P<segment>[A-Z0-9_\\-]{1,10}))?(?P<extension>\\.[A-Za-z0-9]+)?$",
+  "description": "Sentinel-3 product filename (OLCI/SLSTR/SRAL; optional relative orbit, segment, extension).",
+  "filename_pattern": "^(?P<platform>S3A|S3B|S3C)_(?P<instrument>OLCI|SLSTR|SRAL)_(?P<processing_level>L0|L1|L2)_(?P<sensing_datetime>\\d{8}T\\d{6})(?:_(?P<relative_orbit>\\d{3}))?(?:_(?P<segment>[A-Z0-9_\\-]{1,10}))?(?P<extension>\\.[A-Za-z0-9]+)?$",
   "examples": [
     "S3A_OLCI_L2_20250105T103021_080_SEG01.tif",
     "S3B_SRAL_L1_20230715T103021_123.nc"

--- a/src/parseo/schemas/copernicus/sentinel/s4/s4_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s4/s4_filename_v1_0_0.json
@@ -4,7 +4,7 @@
   "stac_version": "1.1.0",
   "stac_extensions": ["processing", "sat", "raster", "eo"],
   "description": "Sentinel-4 product filename (UVN; optional tile, extension).",
-  "filename_pattern": "^(?P<platform>S4A|S4B)_(?P<instrument>UVN)_(?P<processing_level>L1|L2)_(?P<datetime>\\d{8}T\\d{6})(?:_(?P<tile>[A-Z0-9_\\-]{3,10}))?(?P<extension>\\.[A-Za-z0-9]+)?$",
+  "filename_pattern": "^(?P<platform>S4A|S4B)_(?P<instrument>UVN)_(?P<processing_level>L1|L2)_(?P<sensing_datetime>\\d{8}T\\d{6})(?:_(?P<tile>[A-Z0-9_\\-]{3,10}))?(?P<extension>\\.[A-Za-z0-9]+)?$",
   "examples": [
     "S4A_UVN_L2_20250105T103021_EUROPE.tif",
     "S4B_UVN_L1_20240701T101010.nc"

--- a/src/parseo/schemas/copernicus/sentinel/s5p/s5p_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s5p/s5p_filename_v1_0_0.json
@@ -4,7 +4,7 @@
   "stac_version": "1.1.0",
   "stac_extensions": ["processing", "sat", "raster", "eo"],
   "description": "Sentinel-5P product filename (TROPOMI; extension optional).",
-  "filename_pattern": "^(?P<platform>S5P)_(?P<instrument>TROPOMI)_(?P<processing_level>L1B|L2)_(?P<product_type>[A-Z0-9_]{2,12})_(?P<datetime>\\d{8}T\\d{6})(?P<extension>\\.[A-Za-z0-9]+)?$",
+  "filename_pattern": "^(?P<platform>S5P)_(?P<instrument>TROPOMI)_(?P<processing_level>L1B|L2)_(?P<product_type>[A-Z0-9_]{2,12})_(?P<sensing_datetime>\\d{8}T\\d{6})(?P<extension>\\.[A-Za-z0-9]+)?$",
   "examples": [
     "S5P_TROPOMI_L2_NO2_20250105T103021.nc",
     "S5P_TROPOMI_L1B_RA_BD3_20230715T103021.he5"

--- a/src/parseo/schemas/copernicus/sentinel/s6/fields.json
+++ b/src/parseo/schemas/copernicus/sentinel/s6/fields.json
@@ -2,14 +2,15 @@
     "$schema":  "https://json-schema.org/draft/2020-12/schema",
     "title":  "Sentinel-6 Fields",
     "$defs":  {
-                  "satellite":  {
+                 "satellite":  {
                                     "type":  "string",
                                     "values":  [
                                                    {
                                                        "code":  "S6",
                                                        "label":  "Sentinel-6 mission"
                                                    }
-                                               ]
+                                               ],
+                                    "description":  "Mission family"
                                 },
                   "platform":  {
                                    "type":  "string",
@@ -22,7 +23,8 @@
                                                       "code":  "B",
                                                       "label":  "Unit B"
                                                   }
-                                              ]
+                                              ],
+                                   "description":  "Spacecraft unit"
                                },
                   "instrument":  {
                                      "type":  "string",
@@ -31,37 +33,46 @@
                                                         "code":  "P4",
                                                         "label":  "Poseidon-4 Radar Altimeter"
                                                     }
-                                                ]
+                                                ],
+                                     "description":  "Instrument identifier"
                                  },
                   "sampling_rate":  {
                                         "type":  "string",
                                         "values":  [
                                                        {
-                                                           "code":  "1Hz"
+                                                           "code":  "1Hz",
+                                                           "label":  "1 Hz"
                                                        },
                                                        {
-                                                           "code":  "2Hz"
+                                                           "code":  "2Hz",
+                                                           "label":  "2 Hz"
                                                        },
                                                        {
-                                                           "code":  "20Hz"
+                                                           "code":  "20Hz",
+                                                           "label":  "20 Hz"
                                                        }
-                                                   ]
+                                                   ],
+                                        "description":  "Sampling rate"
                                     },
                   "mode":  {
                                "type":  "string",
-                               "pattern":  "^[A-Z]$"
+                               "pattern":  "^[A-Z]$",
+                               "description":  "Measurement mode indicator"
                            },
                   "datetime_compact":  {
                                            "type":  "string",
-                                           "pattern":  "^\\d{8}T\\d{6}$"
+                                           "pattern":  "^\\d{8}T\\d{6}$",
+                                           "description":  "UTC datetime (YYYYMMDDTHHMMSS)"
                                        },
                   "segment":  {
                                   "type":  "string",
-                                  "pattern":  "^\\d{4}$"
+                                  "pattern":  "^\\d{4}$",
+                                  "description":  "Segment number"
                               },
                   "extension":  {
                                     "type":  "string",
-                                    "pattern":  "^[A-Za-z0-9]+$"
+                                    "pattern":  "^[A-Za-z0-9]+$",
+                                    "description":  "File extension without leading dot"
                                 }
               }
 }

--- a/src/parseo/schemas/copernicus/sentinel/s6/index.json
+++ b/src/parseo/schemas/copernicus/sentinel/s6/index.json
@@ -2,10 +2,10 @@
     "$schema":  "https://json-schema.org/draft/2020-12/schema",
     "family":  "S6",
     "versions":  [
-                     {
-                         "file":  "s6_filename_v1_0_0.json",
-                         "version":  "1.0.0",
-                         "status":  "current"
-                     }
-                 ]
+                      {
+                          "status":  "current",
+                          "file":  "s6_filename_v1_0_0.json",
+                          "version":  "1.0.0"
+                      }
+                  ]
 }


### PR DESCRIPTION
## Summary
- Align Sentinel-3 schema with updated field names and regex captures
- Rename datetime captures for Sentinel-4 and Sentinel-5P schemas
- Enrich Sentinel-6 field definitions with descriptions and labels and tidy index

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a97c0f6c548327b3879bd29741e054