### PR TITLE
docs: fix sentinel-2 assemble path

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ fields = {
     "extension": ".SAFE"
 }
 
-filename = assemble("sentinel/s2/s2_filename_v1_0_0.json", fields)
+filename = assemble(fields)
 print(filename)
 # -> S2B_MSIL2A_20241123T224759_N0511_R101_T03VUL_20241123T230829.SAFE
 ```


### PR DESCRIPTION
## Summary
- simplify README's Sentinel-2 assemble example by using default schema

## Testing
- `pip install pre-commit` *(fails: Could not connect to proxy)*
- `pre-commit run --files README.md` *(fails: command not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9853a570c83279167817057f8badb