### PR TITLE
Restrict Sentinel-1 datatake pattern to 6 hex digits

### DIFF
--- a/src/parseo/schemas/copernicus/sentinel/s1/s1_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s1/s1_filename_v1_0_0.json
@@ -47,7 +47,7 @@
     },
     "datatake": {
       "type": "string",
-      "pattern": "^D[0-9A-F]{6,7}$",
+      "pattern": "^D[0-9A-F]{6}$",
       "description": "Datatake ID"
     },
     "product_id": {


### PR DESCRIPTION
## Summary
- Constrain Sentinel-1 datatake field to exactly six hexadecimal characters in schema

## Testing
- `pytest`
- ⚠️ `pre-commit run --files src/parseo/schemas/copernicus/sentinel/s1/s1_filename_v1_0_0.json` *(missing pre-commit; installation blocked by proxy)*


------
https://chatgpt.com/codex/tasks/task_e_68a98a63c8e0832784a4353de5974cfc