### PR TITLE
Enforce MGRS tile layout for Sentinel-2 schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ fields = {
     "datetime": "20241123T224759",
     "version": "N0511",
     "sat_relative_orbit": "R101",
-    "mgrs_tile": "T03VUL",
+    "mgrs_tile": "T03VUL",  # MGRS tile (TxxYYY, e.g., T32TNS)
     "generation_datetime": "20241123T230829",
     "extension": ".SAFE"
 }

--- a/src/parseo/schemas/copernicus/sentinel/s2/s2_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s2/s2_filename_v1_0_0.json
@@ -32,7 +32,7 @@
     },
     "mgrs_tile": {
       "type": "string",
-      "pattern": "^T[0-9A-Z]{5}$",
+      "pattern": "^T\\d{2}[A-Z]{3}$",
       "description": "MGRS tile identifier"
     },
     "generation_datetime": {
@@ -49,6 +49,7 @@
   "filename_pattern": "^(?P<platform>{{platform}})_(?P<processing_level>{{processing_level}})_(?P<sensing_datetime>{{sensing_datetime}})_(?P<processing_baseline>{{processing_baseline}})_(?P<relative_orbit>{{relative_orbit}})_(?P<mgrs_tile>{{mgrs_tile}})_(?P<generation_datetime>{{generation_datetime}})(?:\\.(?P<extension>{{extension}}))?$",
   "examples": [
     "S2B_MSIL2A_20241123T224759_N0511_R101_T03VUL_20241123T230829.SAFE",
-    "S2A_MSIL1C_20230715T103021_N0400_R052_T32TNS_20230715T103555"
+    "S2A_MSIL1C_20230715T103021_N0400_R052_T32TNS_20230715T103555",
+    "S2C_MSIL1C_20250101T000000_N0600_R001_T11UQV_20250101T000100.SAFE"
   ]
 }


### PR DESCRIPTION
## Summary
- tighten Sentinel-2 schema `mgrs_tile` regex to `^T\d{2}[A-Z]{3}$`
- add example filenames with valid MGRS tiles
- clarify MGRS tile format in README

## Testing
- `pytest`
- `pre-commit run --files src/parseo/schemas/copernicus/sentinel/s2/s2_filename_v1_0_0.json README.md` *(fails: command not found; attempted `pip install pre-commit` but 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a98a66aae48327a12e67ad49f3366e