### PR TITLE
docs: fix fastapi example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 # parsEO
 
-**parsEO** is a Python package for **parsing and assembling filenames** of satellite data and derived products.  
+**parsEO** is a Python package for **parsing and assembling filenames** of satellite data and derived products.
 It also serves as an **authoritative definition of filename structures** through machine-readable JSON schemas.
 
 ---
 
 ## Features
 
-- **Bidirectional support**:  
+- **Bidirectional support**:
   Parse existing product filenames into structured fields, and assemble new filenames from fields.
 
-- **Schema-driven**:  
-  Filename rules are defined in JSON schema files under `src/parseo/schemas/`.  
+- **Schema-driven**:
+  Filename rules are defined in JSON schema files under `src/parseo/schemas/`.
   Adding support for a new product = adding a schema, no Python code changes required.
 
-- **Flexible folder structure**:  
-  parsEO does not assume a fixed folder depth. Products can live in arbitrary directory structures,  
+- **Flexible folder structure**:
+  parsEO does not assume a fixed folder depth. Products can live in arbitrary directory structures,
   and the schema only describes the filename itself.
 
-- **Extensible**:  
+- **Extensible**:
   New Copernicus or Landsat product families can be added by dropping schema definitions into the repo.
 
 ---
@@ -27,12 +27,12 @@ It also serves as an **authoritative definition of filename structures** through
 
 Currently included schemas cover:
 
-- **Sentinel missions**: S1, S2, S3, S4, S5P, S6  
-- **Landsat**: LT04, LT05, LE07, LC08, LC09  
+- **Sentinel missions**: S1, S2, S3, S4, S5P, S6
+- **Landsat**: LT04, LT05, LE07, LC08, LC09
 - **Copernicus Land Monitoring Service (CLMS)**:
-  - Corine Land Cover (CLC)  
-  - High Resolution Water & Snow / Ice (HR-WSI)  
-  - High Resolution Layers: Grasslands  
+  - Corine Land Cover (CLC)
+  - High Resolution Water & Snow / Ice (HR-WSI)
+  - High Resolution Layers: Grasslands
 ---
 
 ## Installation
@@ -86,6 +86,111 @@ print(filename)
 # -> S2B_MSIL2A_20241123T224759_N0511_R101_T03VUL_20241123T230829.SAFE
 ```
 
+### Run as a web API
+
+You can expose parsEO over HTTP using [FastAPI](https://fastapi.tiangolo.com).
+The steps below show a minimal, working example from scratch.
+
+1. **Install the required packages**:
+
+   ```bash
+   pip install parseo fastapi uvicorn
+   ```
+
+2. **Save the following as `main.py`**:
+
+   ```python
+   from dataclasses import asdict
+
+   from fastapi import FastAPI
+   from pydantic import BaseModel
+
+   from parseo import assemble, parse_auto
+
+
+   app = FastAPI()
+
+
+   @app.get("/parse")
+   def parse_endpoint(name: str):
+       res = parse_auto(name)
+       # ParseResult is a dataclass; convert to dict for JSON response
+       return asdict(res)
+
+
+   class AssemblePayload(BaseModel):
+       schema: str
+       fields: dict
+
+
+   @app.post("/assemble")
+   def assemble_endpoint(payload: AssemblePayload):
+       filename = assemble(payload.schema, payload.fields)
+       return {"filename": filename}
+   ```
+
+3. **Start the server**:
+
+   ```bash
+   uvicorn main:app --reload
+   ```
+
+4. **Open the Swagger UI** at <http://127.0.0.1:8000/docs> and try the endpoints:
+
+   - `GET /parse` → click **Try it out**, enter a filename such as
+     `S2B_MSIL2A_20241123T224759_N0511_R101_T03VUL_20241123T230829.SAFE`, and
+     press **Execute** to see the parsed fields.
+   - `POST /assemble` → click **Try it out** and paste the JSON body below, then
+     press **Execute** to receive the assembled filename.
+
+     ```json
+     {
+       "schema": "sentinel/s2/s2_filename_v1_0_0.json",
+       "fields": {
+         "platform": "S2B",
+         "processing_level": "MSIL2A",
+         "datetime": "20241123T224759",
+         "version": "N0511",
+         "sat_relative_orbit": "R101",
+         "mgrs_tile": "T03VUL",
+         "generation_datetime": "20241123T230829",
+         "extension": ".SAFE"
+       }
+     }
+     ```
+
+   The response will look like:
+
+   ```json
+   {
+     "filename": "S2B_MSIL2A_20241123T224759_N0511_R101_T03VUL_20241123T230829.SAFE"
+   }
+   ```
+
+   These endpoints can also be called from the command line:
+
+   ```bash
+   curl 'http://127.0.0.1:8000/parse?name=S2B_MSIL2A_20241123T224759_N0511_R101_T03VUL_20241123T230829.SAFE'
+   curl -X POST 'http://127.0.0.1:8000/assemble'\
+     -H 'Content-Type: application/json'\
+     -d '{
+       "schema": "sentinel/s2/s2_filename_v1_0_0.json",
+       "fields": {
+         "platform": "S2B",
+         "processing_level": "MSIL2A",
+         "datetime": "20241123T224759",
+         "version": "N0511",
+         "sat_relative_orbit": "R101",
+         "mgrs_tile": "T03VUL",
+         "generation_datetime": "20241123T230829",
+         "extension": ".SAFE"
+       }
+     }'
+   ```
+
+The interactive Swagger page or the `curl` commands both let you verify that the
+API works as expected.
+
 ---
 
 ## Command Line Interface
@@ -113,15 +218,15 @@ parseo list-schemas
 # The CLI auto-selects a schema based on the first compulsory field.
 
 # Example: Sentinel-2 SAFE (first field: platform)
-parseo assemble \
-  platform=S2B processing_level=MSIL2A datetime=20241123T224759 \
-  version=N0511 sat_relative_orbit=R101 mgrs_tile=T03VUL \
+parseo assemble\
+  platform=S2B processing_level=MSIL2A datetime=20241123T224759\
+  version=N0511 sat_relative_orbit=R101 mgrs_tile=T03VUL\
   generation_datetime=20241123T230829 extension=.SAFE
 # -> S2B_MSIL2A_20241123T224759_N0511_R101_T03VUL_20241123T230829.SAFE
 
 # Example: CLMS HR-WSI product (first field: prefix)
-parseo assemble \
-  prefix=CLMS_WSI product=WIC pixel_spacing=020m tile_id=T33WXP \
+parseo assemble\
+  prefix=CLMS_WSI product=WIC pixel_spacing=020m tile_id=T33WXP\
   sensing_datetime=20201024T103021 platform=S2B version=V100 file_id=WIC extension=.tif
 # -> CLMS_WSI_WIC_020m_T33WXP_20201024T103021_S2B_V100_WIC.tif
 ```
@@ -130,8 +235,8 @@ parseo assemble \
 
 ## Contributing
 
-- Add new schemas under `src/parseo/schemas/<product_family>/`  
-- Include at least one positive example in the schema file  
+- Add new schemas under `src/parseo/schemas/<product_family>/`
+- Include at least one positive example in the schema file
 - Run tests with `pytest`
 
 ---


### PR DESCRIPTION
## Summary
- fix FastAPI example to return dataclass fields via `asdict`
- show multi-line JSON payload for `curl` testing
- strip trailing spaces from README to avoid merge conflicts

## Testing
- `pre-commit run --files README.md` *(fails: command not found)*
- `pip install pre-commit --break-system-packages` *(fails: Could not find a version that satisfies the requirement pre-commit (ProxyError))*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9821d5094832782d57239e3b9cd17