### PR TITLE
Separate sensor and processing level for Sentinel-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ from parseo import assemble
 
 fields = {
     "platform": "S2B",
-    "processing_level": "MSIL2A",
+    "sensor": "MSI",
+    "processing_level": "L2A",
     "datetime": "20241123T224759",
     "version": "N0511",
     "sat_relative_orbit": "R101",
@@ -150,7 +151,7 @@ parseo list-schemas
 
 # Example: Sentinel-2 SAFE (first field: platform)
 parseo assemble \
-  platform=S2B processing_level=MSIL2A datetime=20241123T224759 \
+  platform=S2B sensor=MSI processing_level=L2A datetime=20241123T224759 \
   version=N0511 sat_relative_orbit=R101 mgrs_tile=T03VUL \
   generation_datetime=20241123T230829 extension=.SAFE
 # -> S2B_MSIL2A_20241123T224759_N0511_R101_T03VUL_20241123T230829.SAFE

--- a/src/parseo/schemas/copernicus/sentinel/s2/s2_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s2/s2_filename_v1_0_0.json
@@ -3,16 +3,21 @@
   "schema_version": "1.0.0",
   "stac_version": "1.1.0",
   "stac_extensions": ["processing", "sat", "raster", "eo", "mgrs"],
-  "description": "Sentinel-2 SAFE product filename (MSIL1C/MSIL2A; extension optional).",
+  "description": "Sentinel-2 SAFE product filename (MSI sensor, processing levels L1C/L2A; extension optional).",
   "fields": {
     "platform": {
       "type": "string",
       "enum": ["S2A", "S2B", "S2C"],
       "description": "Spacecraft unit"
     },
+    "sensor": {
+      "type": "string",
+      "enum": ["MSI"],
+      "description": "Sensor"
+    },
     "processing_level": {
       "type": "string",
-      "enum": ["MSIL1C", "MSIL2A"],
+      "enum": ["L1C", "L2A"],
       "description": "Processing level"
     },
     "sensing_datetime": {
@@ -46,7 +51,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "filename_pattern": "^(?P<platform>{{platform}})_(?P<processing_level>{{processing_level}})_(?P<sensing_datetime>{{sensing_datetime}})_(?P<processing_baseline>{{processing_baseline}})_(?P<relative_orbit>{{relative_orbit}})_(?P<mgrs_tile>{{mgrs_tile}})_(?P<generation_datetime>{{generation_datetime}})(?:\\.(?P<extension>{{extension}}))?$",
+  "filename_pattern": "^(?P<platform>{{platform}})_(?P<sensor>{{sensor}})(?P<processing_level>{{processing_level}})_(?P<sensing_datetime>{{sensing_datetime}})_(?P<processing_baseline>{{processing_baseline}})_(?P<relative_orbit>{{relative_orbit}})_(?P<mgrs_tile>{{mgrs_tile}})_(?P<generation_datetime>{{generation_datetime}})(?:\\.(?P<extension>{{extension}}))?$",
   "examples": [
     "S2B_MSIL2A_20241123T224759_N0511_R101_T03VUL_20241123T230829.SAFE",
     "S2A_MSIL1C_20230715T103021_N0400_R052_T32TNS_20230715T103555",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -8,7 +8,8 @@ def test_s2_example():
     res = parse_auto(name)
     assert res is not None
     assert res.fields["platform"] == "S2B"
-    assert res.fields["processing_level"] == "MSIL2A"
+    assert res.fields["sensor"] == "MSI"
+    assert res.fields["processing_level"] == "L2A"
     assert res.fields["sensing_datetime"] == "20241123T224759"
     assert res.fields["processing_baseline"] == "N0511"
     assert res.fields["relative_orbit"] == "R101"


### PR DESCRIPTION
## Summary
- split Sentinel-2 MSIL* field into `sensor` and `processing_level`
- document and test new fields

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9d8f37a748327a67931c7bb38a35f