### PR TITLE
Harmonize schema templates with optional extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,11 +188,13 @@ Adding support for a new product requires only a JSON schema placed under
      listed there is optional.
 
 4. **Describe the filename structure**
-   - The `"filename_pattern"` regex stitches the fields together using
-     named groups: `(?P<name>{{name}})`.
-   - Field order is defined intrinsically by the order of these groups.
-   - Optional segments are wrapped in non‑capturing groups with `?` so their
-     preceding separators vanish when absent.
+   - Provide a `"template"` string that arranges fields using `{field}`
+     placeholders. Optional parts can be wrapped in square brackets, e.g.,
+     `[.{extension}]`.
+   - At runtime the template is compiled into a regex by replacing each
+     placeholder with the field's pattern or enum values.
+   - Placeholder order in the template defines `fields_order` for
+     filename assembly.
 
 5. **Provide examples**
    - Include an `"examples"` array showing valid filenames with and without

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/fsc_filename_structure.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/fsc_filename_structure.json
@@ -41,22 +41,11 @@
                 },
     "extension":  {
                       "codes":  [
-                                    ".tif",
-                                    ".xml"
+                                    "tif",
+                                    "xml"
                                 ]
                   },
-    "filename_pattern":  "^(?P\u003cprefix\u003eCLMS_WSI)_(?P\u003cproduct\u003eFSC)_(?P\u003cpixel_spacing\u003e020m)_(?P\u003ctile_id\u003eT\\d{2}[C-HJ-NP-X][A-Z]{2})_(?P\u003csensing_datetime\u003e(?:19|20)\\d\\d(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\\d|3[01])T(?:[01]\\d|2[0-3])(?:[0-5]\\d){2})_(?P\u003cplatform\u003eS2A|S2B)_(?P\u003cversion\u003eV\\d{3})_(?P\u003cfile_id\u003eFSCOG|FSCOG-QA|QAFLAGS|CLD|NDSI|MTD)(?P\u003cextension\u003e\\.(?:tif|xml))$",
-    "fields_order":  [
-                         "prefix",
-                         "product",
-                         "pixel_spacing",
-                         "tile_id",
-                         "sensing_datetime",
-                         "platform",
-                         "version",
-                         "file_id",
-                         "extension"
-                     ],
+    "template":  "{prefix}_{product}_{pixel_spacing}_{tile_id}_{sensing_datetime}_{platform}_{version}_{file_id}[.{extension}]",
     "valid_examples":  [
                            "CLMS_WSI_FSC_020m_T32TNS_20211018T103021_S2A_V100_FSCOG.tif"
                        ]

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/wic_s2_filename_structure.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/wic_s2_filename_structure.json
@@ -40,22 +40,11 @@
                 },
     "extension":  {
                       "codes":  [
-                                    ".tif",
-                                    ".xml"
+                                    "tif",
+                                    "xml"
                                 ]
                   },
-    "filename_pattern":  "^(?P\u003cprefix\u003eCLMS_WSI)_(?P\u003cproduct\u003eWIC)_(?P\u003cpixel_spacing\u003e020m)_(?P\u003ctile_id\u003eT\\d{2}[C-HJ-NP-X][A-Z]{2})_(?P\u003csensing_datetime\u003e(?:19|20)\\d\\d(?:0[1-9]|1[0-2])(?:0[1-9]|[12]\\d|3[01])T(?:[01]\\d|2[0-3])(?:[0-5]\\d){2})_(?P\u003cplatform\u003eS2A|S2B)_(?P\u003cversion\u003eV\\d{3})_(?P\u003cfile_id\u003eWIC|PRB|QAFLAGS|WIC-QA|MTD)(?P\u003cextension\u003e\\.(?:tif|xml))$",
-    "fields_order":  [
-                         "prefix",
-                         "product",
-                         "pixel_spacing",
-                         "tile_id",
-                         "sensing_datetime",
-                         "platform",
-                         "version",
-                         "file_id",
-                         "extension"
-                     ],
+    "template":  "{prefix}_{product}_{pixel_spacing}_{tile_id}_{sensing_datetime}_{platform}_{version}_{file_id}[.{extension}]",
     "valid_examples":  [
                            "CLMS_WSI_WIC_020m_T31TCH_20160720T105547_S2A_V100_WIC-QA.tif",
                            "CLMS_WSI_WIC_020m_T33WXP_20201024T103021_S2B_V100_PRB.tif",

--- a/src/parseo/schemas/copernicus/sentinel/s1/s1_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s1/s1_filename_v1_0_0.json
@@ -61,7 +61,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "filename_pattern": "^(?P<platform>{{platform}})_(?P<mode>{{mode}})_(?P<product>{{product}})_(?P<level>{{level}})(?P<pol>{{pol}})_(?P<start_datetime>{{start_datetime}})_(?P<end_datetime>{{end_datetime}})_(?P<abs_orbit>{{abs_orbit}})_(?P<datatake>{{datatake}})_(?P<product_id>{{product_id}})(?:\\.(?P<extension>{{extension}}))?$",
+  "template": "{platform}_{mode}_{product}_{level}{pol}_{start_datetime}_{end_datetime}_{abs_orbit}_{datatake}_{product_id}[.{extension}]",
   "examples": [
     "S1A_IW_SLC__1SDVV_20250105T053021_20250105T053048_A054321_D068F2E_ABC123.SAFE",
     "S1B_EW_GRDH_1SHHH_20190101T000000_20190101T000030_A012345_D0ABCDE_ABCDEF",

--- a/src/parseo/schemas/copernicus/sentinel/s2/s2_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s2/s2_filename_v1_0_0.json
@@ -51,7 +51,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "filename_pattern": "^(?P<platform>{{platform}})_(?P<sensor>{{sensor}})(?P<processing_level>{{processing_level}})_(?P<sensing_datetime>{{sensing_datetime}})_(?P<processing_baseline>{{processing_baseline}})_(?P<relative_orbit>{{relative_orbit}})_(?P<mgrs_tile>{{mgrs_tile}})_(?P<generation_datetime>{{generation_datetime}})(?:\\.(?P<extension>{{extension}}))?$",
+  "template": "{platform}_{sensor}{processing_level}_{sensing_datetime}_{processing_baseline}_{relative_orbit}_{mgrs_tile}_{generation_datetime}[.{extension}]",
   "examples": [
     "S2B_MSIL2A_20241123T224759_N0511_R101_T03VUL_20241123T230829.SAFE",
     "S2A_MSIL1C_20230715T103021_N0400_R052_T32TNS_20230715T103555",

--- a/src/parseo/schemas/copernicus/sentinel/s3/s3_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s3/s3_filename_v1_0_0.json
@@ -4,7 +4,16 @@
   "stac_version": "1.1.0",
   "stac_extensions": ["processing", "sat", "raster", "eo"],
   "description": "Sentinel-3 product filename (OLCI/SLSTR/SRAL; optional relative orbit, segment, extension).",
-  "filename_pattern": "^(?P<platform>S3A|S3B|S3C)_(?P<instrument>OLCI|SLSTR|SRAL)_(?P<processing_level>L0|L1|L2)_(?P<sensing_datetime>\\d{8}T\\d{6})(?:_(?P<relative_orbit>\\d{3}))?(?:_(?P<segment>[A-Z0-9_\\-]{1,10}))?(?P<extension>\\.[A-Za-z0-9]+)?$",
+  "fields": {
+    "platform": {"type": "string", "enum": ["S3A", "S3B", "S3C"]},
+    "instrument": {"type": "string", "enum": ["OLCI", "SLSTR", "SRAL"]},
+    "processing_level": {"type": "string", "enum": ["L0", "L1", "L2"]},
+    "sensing_datetime": {"type": "string", "pattern": "^\\d{8}T\\d{6}$"},
+    "relative_orbit": {"type": "string", "pattern": "^\\d{3}$"},
+    "segment": {"type": "string", "pattern": "^[A-Z0-9_\\-]{1,10}$"},
+    "extension": {"type": "string", "pattern": "^[A-Za-z0-9]+$", "description": "File extension without leading dot"}
+  },
+  "template": "{platform}_{instrument}_{processing_level}_{sensing_datetime}[_{relative_orbit}][_{segment}][.{extension}]",
   "examples": [
     "S3A_OLCI_L2_20250105T103021_080_SEG01.tif",
     "S3B_SRAL_L1_20230715T103021_123.nc"

--- a/src/parseo/schemas/copernicus/sentinel/s4/s4_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s4/s4_filename_v1_0_0.json
@@ -4,7 +4,15 @@
   "stac_version": "1.1.0",
   "stac_extensions": ["processing", "sat", "raster", "eo"],
   "description": "Sentinel-4 product filename (UVN; optional tile, extension).",
-  "filename_pattern": "^(?P<platform>S4A|S4B)_(?P<instrument>UVN)_(?P<processing_level>L1|L2)_(?P<sensing_datetime>\\d{8}T\\d{6})(?:_(?P<tile>[A-Z0-9_\\-]{3,10}))?(?P<extension>\\.[A-Za-z0-9]+)?$",
+  "fields": {
+    "platform": {"type": "string", "enum": ["S4A", "S4B"]},
+    "instrument": {"type": "string", "enum": ["UVN"]},
+    "processing_level": {"type": "string", "enum": ["L1", "L2"]},
+    "sensing_datetime": {"type": "string", "pattern": "^\\d{8}T\\d{6}$"},
+    "tile": {"type": "string", "pattern": "^[A-Z0-9_\\-]{3,10}$"},
+    "extension": {"type": "string", "pattern": "^[A-Za-z0-9]+$", "description": "File extension without leading dot"}
+  },
+  "template": "{platform}_{instrument}_{processing_level}_{sensing_datetime}[_{tile}][.{extension}]",
   "examples": [
     "S4A_UVN_L2_20250105T103021_EUROPE.tif",
     "S4B_UVN_L1_20240701T101010.nc"

--- a/src/parseo/schemas/copernicus/sentinel/s5p/s5p_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s5p/s5p_filename_v1_0_0.json
@@ -4,7 +4,15 @@
   "stac_version": "1.1.0",
   "stac_extensions": ["processing", "sat", "raster", "eo"],
   "description": "Sentinel-5P product filename (TROPOMI; extension optional).",
-  "filename_pattern": "^(?P<platform>S5P)_(?P<instrument>TROPOMI)_(?P<processing_level>L1B|L2)_(?P<product_type>[A-Z0-9_]{2,12})_(?P<sensing_datetime>\\d{8}T\\d{6})(?P<extension>\\.[A-Za-z0-9]+)?$",
+  "fields": {
+    "platform": {"type": "string", "enum": ["S5P"]},
+    "instrument": {"type": "string", "enum": ["TROPOMI"]},
+    "processing_level": {"type": "string", "enum": ["L1B", "L2"]},
+    "product_type": {"type": "string", "pattern": "^[A-Z0-9_]{2,12}$"},
+    "sensing_datetime": {"type": "string", "pattern": "^\\d{8}T\\d{6}$"},
+    "extension": {"type": "string", "pattern": "^[A-Za-z0-9]+$", "description": "File extension without leading dot"}
+  },
+  "template": "{platform}_{instrument}_{processing_level}_{product_type}_{sensing_datetime}[.{extension}]",
   "examples": [
     "S5P_TROPOMI_L2_NO2_20250105T103021.nc",
     "S5P_TROPOMI_L1B_RA_BD3_20230715T103021.he5"

--- a/src/parseo/schemas/copernicus/sentinel/s6/s6_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s6/s6_filename_v1_0_0.json
@@ -4,7 +4,17 @@
   "stac_version": "1.1.0",
   "stac_extensions": ["processing", "sat"],
   "description": "Sentinel-6 product filename (P4 altimetry; extension optional).",
-  "filename_pattern": "^(?P<platform>S6A|S6B)_(?P<instrument>P4)_(?P<sampling_rate>1Hz|2Hz|20Hz)(?P<mode>[A-Z])_(?P<start_datetime>\\d{8}T\\d{6})_(?P<end_datetime>\\d{8}T\\d{6})_(?P<segment>\\d{4})(?P<extension>\\.[A-Za-z0-9]+)?$",
+  "fields": {
+    "platform": {"type": "string", "enum": ["S6A", "S6B"]},
+    "instrument": {"type": "string", "enum": ["P4"]},
+    "sampling_rate": {"type": "string", "enum": ["1Hz", "2Hz", "20Hz"]},
+    "mode": {"type": "string", "pattern": "^[A-Z]$"},
+    "start_datetime": {"type": "string", "pattern": "^\\d{8}T\\d{6}$"},
+    "end_datetime": {"type": "string", "pattern": "^\\d{8}T\\d{6}$"},
+    "segment": {"type": "string", "pattern": "^\\d{4}$"},
+    "extension": {"type": "string", "pattern": "^[A-Za-z0-9]+$", "description": "File extension without leading dot"}
+  },
+  "template": "{platform}_{instrument}_{sampling_rate}{mode}_{start_datetime}_{end_datetime}_{segment}[.{extension}]",
   "examples": [
     "S6A_P4_20HzN_20221015T103529_20221015T112143_0001.nc",
     "S6B_P4_1HzN_20230715T103021_20230715T103121_0002"

--- a/src/parseo/template.py
+++ b/src/parseo/template.py
@@ -1,0 +1,64 @@
+import re
+from typing import Dict, Tuple, List
+
+def _field_regex(spec: Dict | None) -> str:
+    """Return a regex for a field spec.
+
+    If *spec* is missing or empty, a permissive pattern ``.+`` is used.
+    Anchors in patterns are stripped so they integrate into larger regexes.
+    """
+    if not spec:
+        return ".+"
+    if "enum" in spec:
+        return "(?:" + "|".join(re.escape(v) for v in spec["enum"]) + ")"
+    pattern = spec.get("pattern")
+    if pattern is None:
+        raise KeyError("Field spec missing 'pattern' or 'enum'")
+    if pattern.startswith("^"):
+        pattern = pattern[1:]
+    if pattern.endswith("$"):
+        pattern = pattern[:-1]
+    return pattern
+
+def compile_template(template: str, fields: Dict[str, Dict]) -> Tuple[str, List[str]]:
+    """Compile *template* into a regex pattern and extract field order.
+
+    ``{field}`` placeholders are replaced using patterns or enums from
+    *fields*. Optional segments can be denoted with ``[ ... ]`` and will be
+    converted into non-capturing optional groups. The returned pattern is
+    anchored with ``^`` and ``$``.
+    """
+    order: List[str] = []
+
+    def _compile(segment: str) -> str:
+        result = ""
+        i = 0
+        while i < len(segment):
+            ch = segment[i]
+            if ch == "{":
+                j = segment.index("}", i)
+                name = segment[i + 1 : j]
+                if name not in order:
+                    order.append(name)
+                regex = _field_regex(fields.get(name))
+                result += f"(?P<{name}>{regex})"
+                i = j + 1
+            elif ch == "[":
+                depth = 1
+                j = i + 1
+                while j < len(segment) and depth:
+                    if segment[j] == "[":
+                        depth += 1
+                    elif segment[j] == "]":
+                        depth -= 1
+                    j += 1
+                inner = segment[i + 1 : j - 1]
+                result += f"(?:{_compile(inner)})?"
+                i = j
+            else:
+                result += re.escape(ch)
+                i += 1
+        return result
+
+    pattern = "^" + _compile(template) + "$"
+    return pattern, order

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -56,7 +56,10 @@ def test_schema_paths_cached(monkeypatch):
 def test_parse_bom_schema(tmp_path, monkeypatch):
     import json
 
-    schema = {"filename_pattern": r"^(?P<id>ABC)\.SAFE$"}
+    schema = {
+        "template": "{id}.SAFE",
+        "fields": {"id": {"enum": ["ABC"]}},
+    }
     bom_path = tmp_path / "bom_schema.json"
     bom_path.write_text("\ufeff" + json.dumps(schema), encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- Remove leading dots from extension codes in CLMS FSC and WIC S2 schemas and make extensions optional with `[.{extension}]`
- Normalize Sentinel-3/4/5P/6 schemas to expect extensions without a dot and compile templates accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9de804bbc8327ac5b5b7fcbbde7e5