### PR TITLE
fix: enable Python 3.9 compatibility for template

### DIFF
--- a/src/parseo/template.py
+++ b/src/parseo/template.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from typing import Dict, Tuple, List
 


### PR DESCRIPTION
## Summary
- add future annotations import to template module for 3.9 compatibility

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa23a0d8f48327826e91ced9800c6b