### PR TITLE
Expose schema version and status in parser output

### DIFF
--- a/src/parseo/cli.py
+++ b/src/parseo/cli.py
@@ -123,9 +123,12 @@ def main(argv: List[str] | None = None) -> int:
             "valid": bool(getattr(res, "valid", False)),
             "fields": getattr(res, "fields", None),
         }
-        spath = getattr(res, "schema_path", None)
-        if spath:
-            out["schema_path"] = spath
+        version = getattr(res, "version", None)
+        if version:
+            out["version"] = version
+        status = getattr(res, "status", None)
+        if status:
+            out["status"] = status
         mfam = getattr(res, "match_family", None)
         if mfam:
             out["match_family"] = mfam

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -23,6 +23,8 @@ def test_s1_example():
     assert res.fields["product_type"] == "SLC_"
     assert res.fields["processing_level"] == "1SD"
     assert res.fields["polarization"] == "V"
+    assert res.version == "1.0.0"
+    assert res.status == "current"
 
 
 def test_s3_example():


### PR DESCRIPTION
## Summary
- drop schema_path from CLI parse response
- surface schema version and status in ParseResult and CLI output
- test sentinel-1 parsing for version and status

## Testing
- `pre-commit run --files src/parseo/parser.py src/parseo/cli.py tests/test_parser.py` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa2402822483278db63578bd251071