### PR TITLE
Add schema info utilities and CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,18 @@ parseo parse S1A_IW_SLC__1SDV_20250105T053021_20250105T053048_A054321_D068F2E_AB
 # List available schemas
 parseo list-schemas
 
+# Inspect a specific schema
+parseo schema-info S2
+# -> {
+#      "schema_id": "copernicus:sentinel:s2",
+#      "description": "Sentinel-2 product filename (MSI sensor, processing levels L1C/L2A; extension optional).",
+#      "fields": {
+#        "platform": {"type": "string", "enum": ["S2A", "S2B", "S2C"], "description": "Spacecraft unit"},
+#        "sensor": {"type": "string", "enum": ["MSI"], "description": "Sensor"},
+#        ...
+#      }
+#    }
+
 # Assemble a filename from fields.
 # The CLI auto-selects a schema based on the first compulsory field.
 

--- a/src/parseo/cli.py
+++ b/src/parseo/cli.py
@@ -8,7 +8,7 @@ from importlib.resources import as_file, files
 from pathlib import Path
 from typing import Any, Dict, List
 
-from parseo.parser import parse_auto  # existing parser entrypoint
+from parseo.parser import parse_auto, describe_schema  # parser helpers
 
 SCHEMAS_ROOT = "schemas"
 
@@ -25,6 +25,10 @@ def _build_arg_parser() -> argparse.ArgumentParser:
 
     # list-schemas
     sp.add_parser("list-schemas", help="List packaged schema JSON files")
+
+    # schema-info
+    p_info = sp.add_parser("schema-info", help="Show details for a mission family")
+    p_info.add_argument("family", help="Mission family name, e.g. 'S2'")
 
     # assemble
     p_asm = sp.add_parser(
@@ -141,6 +145,14 @@ def main(argv: List[str] | None = None) -> int:
             root = Path(bp)
             for p in root.rglob("*.json"):
                 print(p.relative_to(root))
+        return 0
+
+    if args.cmd == "schema-info":
+        try:
+            info = describe_schema(args.family)
+        except KeyError as e:
+            raise SystemExit(str(e))
+        print(json.dumps(info, indent=2, ensure_ascii=False))
         return 0
 
     if args.cmd == "assemble":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,8 +2,10 @@ import sys
 import builtins
 import io
 import pytest
+import json
 
 from parseo import cli
+from parseo.parser import list_schemas
 
 
 def test_cli_assemble_success(capsys):
@@ -70,3 +72,18 @@ def test_fields_json_invalid_stdin(monkeypatch):
     with pytest.raises(SystemExit) as exc:
         cli.main()
     assert "--fields-json '-' is not valid JSON" in str(exc.value)
+
+
+def test_list_schemas_exposes_known_families():
+    fams = list_schemas()
+    assert "S2" in fams
+    assert "S1" in fams
+
+
+def test_cli_schema_info(capsys):
+    assert cli.main(["schema-info", "S2"]) == 0
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["schema_id"] == "copernicus:sentinel:s2"
+    assert "platform" in data["fields"]
+    assert data["fields"]["platform"]["description"] == "Spacecraft unit"


### PR DESCRIPTION
## Summary
- expose `list_schemas` and `describe_schema` helpers for inspecting packaged filename schemas
- extend CLI with new `schema-info` command
- document schema inspection usage in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa2528d7b883278b80943e7c291427