### PR TITLE
feat: add detailed parse error handling

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -34,6 +34,16 @@ def test_s3_example():
     assert res.fields["platform"] == "S3A"
 
 
+def test_near_miss_reports_field():
+    name = "S2X_MSIL2A_20241123T224759_N0511_R101_T03VUL_20241123T230829.SAFE"
+    with pytest.raises(parser.ParseError) as exc:
+        parse_auto(name)
+    msg = str(exc.value)
+    assert "platform" in msg
+    assert "S2X" in msg
+    assert "S2A" in msg
+
+
 def test_schema_paths_cached(monkeypatch):
     calls = {"n": 0}
 


### PR DESCRIPTION
## Summary
- add ParseError with field-specific details
- implement `_explain_match_failure` to pinpoint failing regex field
- raise ParseError from `parse_auto` when a near miss occurs and cover with tests

## Testing
- `pytest`
- `pre-commit run --files src/parseo/parser.py tests/test_parser.py` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa263627b08327be0a22c00e9bc25a