### PR TITLE
Use list_schemas helper for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,14 @@ parseo parse S1A_IW_SLC__1SDV_20250105T053021_20250105T053048_A054321_D068F2E_AB
 
 # List available schemas
 parseo list-schemas
+# -> CLC
+#    LANDSAT
+#    S1
+#    S2
+#    S3
+#    S4
+#    S5P
+#    S6
 
 # Inspect a specific schema
 parseo schema-info S2

--- a/src/parseo/cli.py
+++ b/src/parseo/cli.py
@@ -4,13 +4,9 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from importlib.resources import as_file, files
-from pathlib import Path
 from typing import Any, Dict, List
 
-from parseo.parser import parse_auto, describe_schema  # parser helpers
-
-SCHEMAS_ROOT = "schemas"
+from parseo.parser import parse_auto, describe_schema, list_schemas  # parser helpers
 
 
 # ---------- small utilities ----------
@@ -24,7 +20,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     p_parse.add_argument("filename")
 
     # list-schemas
-    sp.add_parser("list-schemas", help="List packaged schema JSON files")
+    sp.add_parser("list-schemas", help="List available schema families")
 
     # schema-info
     p_info = sp.add_parser("schema-info", help="Show details for a mission family")
@@ -140,11 +136,8 @@ def main(argv: List[str] | None = None) -> int:
         return 0
 
     if args.cmd == "list-schemas":
-        base = files("parseo").joinpath(SCHEMAS_ROOT)
-        with as_file(base) as bp:
-            root = Path(bp)
-            for p in root.rglob("*.json"):
-                print(p.relative_to(root))
+        for fam in list_schemas():
+            print(fam)
         return 0
 
     if args.cmd == "schema-info":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -80,6 +80,14 @@ def test_list_schemas_exposes_known_families():
     assert "S1" in fams
 
 
+def test_cli_list_schemas_outputs_families(capsys):
+    assert cli.main(["list-schemas"]) == 0
+    out = capsys.readouterr().out.splitlines()
+    assert "S1" in out
+    assert "S2" in out
+    assert all("index.json" not in line for line in out)
+
+
 def test_cli_schema_info(capsys):
     assert cli.main(["schema-info", "S2"]) == 0
     out = capsys.readouterr().out


### PR DESCRIPTION
## Summary
- Simplify `list-schemas` command to use `parseo.parser.list_schemas`
- Document new `list-schemas` output and add CLI regression test

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa271010908327948901544d15fdbc