### PR TITLE
Expose schema template and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,11 @@ parseo schema-info S2
 # -> {
 #      "schema_id": "copernicus:sentinel:s2",
 #      "description": "Sentinel-2 product filename (MSI sensor, processing levels L1C/L2A; extension optional).",
+#      "template": "{platform}_{sensor}{processing_level}_{sensing_datetime}_..._[.{extension}]",
+#      "examples": [
+#        "S2B_MSIL2A_20241123T224759_N0511_R101_T03VUL_20241123T230829.SAFE",
+#        "..."
+#      ],
 #      "fields": {
 #        "platform": {"type": "string", "enum": ["S2A", "S2B", "S2C"], "description": "Spacecraft unit"},
 #        "sensor": {"type": "string", "enum": ["MSI"], "description": "Sensor"},

--- a/src/parseo/parser.py
+++ b/src/parseo/parser.py
@@ -297,11 +297,21 @@ def describe_schema(family: str, pkg: str = __package__) -> dict[str, Any]:
                 if k in spec
             }
 
-    return {
+    out: Dict[str, Any] = {
         "schema_id": schema.get("schema_id"),
         "description": schema.get("description"),
         "fields": fields,
     }
+
+    template = schema.get("template")
+    if isinstance(template, str):
+        out["template"] = template
+
+    examples = schema.get("examples")
+    if isinstance(examples, list):
+        out["examples"] = [e for e in examples if isinstance(e, str)]
+
+    return out
 
 
 def parse_auto(name: str) -> ParseResult:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -95,3 +95,7 @@ def test_cli_schema_info(capsys):
     assert data["schema_id"] == "copernicus:sentinel:s2"
     assert "platform" in data["fields"]
     assert data["fields"]["platform"]["description"] == "Spacecraft unit"
+    assert isinstance(data.get("template"), str)
+    assert isinstance(data.get("examples"), list)
+    assert data["examples"]
+    assert all(isinstance(x, str) for x in data["examples"])


### PR DESCRIPTION
## Summary
- include template and example filenames in schema-info output
- test CLI `schema-info` for template and examples
- document new fields in README schema-info example

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa28a16b888327a28849fb2212aac8