### PR TITLE
docs: update field names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,12 @@ fields = {
     "platform": "S2B",
     "sensor": "MSI",
     "processing_level": "L2A",
-    "datetime": "20241123T224759",
-    "version": "N0511",
-    "sat_relative_orbit": "R101",
+    "sensing_datetime": "20241123T224759",
+    "processing_baseline": "N0511",
+    "relative_orbit": "R101",
     "mgrs_tile": "T03VUL",  # MGRS tile (TxxYYY, e.g., T32TNS)
     "generation_datetime": "20241123T230829",
-    "extension": ".SAFE",
+    "extension": "SAFE",
 }
 
 filename = assemble(schema_path, fields)
@@ -99,12 +99,12 @@ fields = {
     "platform": "S2B",
     "sensor": "MSI",
     "processing_level": "L2A",
-    "datetime": "20241123T224759",
-    "version": "N0511",
-    "sat_relative_orbit": "R101",
+    "sensing_datetime": "20241123T224759",
+    "processing_baseline": "N0511",
+    "relative_orbit": "R101",
     "mgrs_tile": "T03VUL",
     "generation_datetime": "20241123T230829",
-    "extension": ".SAFE",
+    "extension": "SAFE",
 }
 
 filename = assemble_auto(fields)
@@ -201,15 +201,15 @@ parseo schema-info S2
 
 # Example: Sentinel-2 SAFE (first field: platform)
 parseo assemble \
-  platform=S2B sensor=MSI processing_level=L2A datetime=20241123T224759 \
-  version=N0511 sat_relative_orbit=R101 mgrs_tile=T03VUL \
-  generation_datetime=20241123T230829 extension=.SAFE
+  platform=S2B sensor=MSI processing_level=L2A sensing_datetime=20241123T224759 \
+  processing_baseline=N0511 relative_orbit=R101 mgrs_tile=T03VUL \
+  generation_datetime=20241123T230829 extension=SAFE
 # -> S2B_MSIL2A_20241123T224759_N0511_R101_T03VUL_20241123T230829.SAFE
 
 # Example: CLMS HR-WSI product (first field: prefix)
 parseo assemble \
   prefix=CLMS_WSI product=WIC pixel_spacing=020m tile_id=T33WXP \
-  sensing_datetime=20201024T103021 platform=S2B version=V100 file_id=WIC extension=.tif
+  sensing_datetime=20201024T103021 platform=S2B processing_baseline=V100 file_id=WIC extension=tif
 # -> CLMS_WSI_WIC_020m_T33WXP_20201024T103021_S2B_V100_WIC.tif
 ```
 


### PR DESCRIPTION
## Summary
- replace outdated field names with `sensing_datetime`, `processing_baseline`, and `relative_orbit`
- drop leading dot from `extension` values in examples

## Testing
- `pytest`
- `pre-commit run --files README.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa369dd70c8327bdb868bc8da3ec63