### PR TITLE
Add EUMETSAT schemas for MTG and Metop

### DIFF
--- a/src/parseo/schemas/eumetsat/metop/index.json
+++ b/src/parseo/schemas/eumetsat/metop/index.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "family": "METOP",
+    "versions": [
+        {
+            "status": "current",
+            "file": "metop_filename_v1_0_0.json",
+            "version": "1.0.0"
+        }
+    ]
+}

--- a/src/parseo/schemas/eumetsat/metop/metop_filename_v1_0_0.json
+++ b/src/parseo/schemas/eumetsat/metop/metop_filename_v1_0_0.json
@@ -1,0 +1,52 @@
+{
+  "schema_id": "eumetsat:metop",
+  "schema_version": "1.0.0",
+  "fields": {
+    "platform": {
+      "type": "string",
+      "enum": ["M01", "M02", "M03"],
+      "description": "Spacecraft unit"
+    },
+    "instrument": {
+      "type": "string",
+      "enum": ["AVHR", "IASI", "ASCAT"],
+      "description": "Instrument short name"
+    },
+    "processing_level": {
+      "type": "string",
+      "enum": ["L1B", "L2"],
+      "description": "Processing level"
+    },
+    "start_datetime": {
+      "type": "string",
+      "pattern": "^\\d{8}T\\d{6}Z$",
+      "description": "Acquisition start time (UTC, YYYYMMDDTHHMMSSZ)"
+    },
+    "end_datetime": {
+      "type": "string",
+      "pattern": "^\\d{8}T\\d{6}Z$",
+      "description": "Acquisition end time (UTC, YYYYMMDDTHHMMSSZ)"
+    },
+    "orbit_number": {
+      "type": "string",
+      "pattern": "^O\\d{6}$",
+      "description": "Orbit number"
+    },
+    "collection": {
+      "type": "string",
+      "pattern": "^C\\d{2}$",
+      "description": "Collection identifier"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^\\d{2}$",
+      "description": "Product version"
+    },
+    "extension": {
+      "type": "string",
+      "enum": ["nc"],
+      "description": "File extension without leading dot"
+    }
+  },
+  "template": "{platform}_{instrument}_{processing_level}_{start_datetime}_{end_datetime}_{orbit_number}_{collection}_V{version}[.{extension}]"
+}

--- a/src/parseo/schemas/eumetsat/mtg/index.json
+++ b/src/parseo/schemas/eumetsat/mtg/index.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "family": "MTG",
+    "versions": [
+        {
+            "status": "current",
+            "file": "mtg_filename_v1_0_0.json",
+            "version": "1.0.0"
+        }
+    ]
+}

--- a/src/parseo/schemas/eumetsat/mtg/mtg_filename_v1_0_0.json
+++ b/src/parseo/schemas/eumetsat/mtg/mtg_filename_v1_0_0.json
@@ -1,0 +1,47 @@
+{
+  "schema_id": "eumetsat:mtg",
+  "schema_version": "1.0.0",
+  "fields": {
+    "platform": {
+      "type": "string",
+      "enum": ["MTG-I1", "MTG-I2", "MTG-S1", "MTG-S2"],
+      "description": "Spacecraft unit"
+    },
+    "instrument": {
+      "type": "string",
+      "enum": ["FCI", "LI", "IRS", "UVN"],
+      "description": "Instrument short name"
+    },
+    "product_type": {
+      "type": "string",
+      "pattern": "^[A-Z0-9_]{2,10}$",
+      "description": "Product short name"
+    },
+    "processing_level": {
+      "type": "string",
+      "enum": ["L1", "L2"],
+      "description": "Processing level"
+    },
+    "start_datetime": {
+      "type": "string",
+      "pattern": "^\\d{8}T\\d{6}Z$",
+      "description": "Acquisition start time (UTC, YYYYMMDDTHHMMSSZ)"
+    },
+    "end_datetime": {
+      "type": "string",
+      "pattern": "^\\d{8}T\\d{6}Z$",
+      "description": "Acquisition end time (UTC, YYYYMMDDTHHMMSSZ)"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^\\d{2}$",
+      "description": "Product version"
+    },
+    "extension": {
+      "type": "string",
+      "enum": ["nc"],
+      "description": "File extension without leading dot"
+    }
+  },
+  "template": "{platform}_{instrument}_{product_type}_{processing_level}_{start_datetime}_{end_datetime}_V{version}[.{extension}]"
+}


### PR DESCRIPTION
## Summary
- define MTG and Metop filename schemas
- expose current schema versions for MTG and Metop

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa37b8a6908327b791dc3e32f7f7c0