### PR TITLE
Add CLMS HR-VPP FAPAR schema and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Currently included schemas cover:
 - **Copernicus Land Monitoring Service (CLMS)**:
   - Corine Land Cover (CLC)  
   - High Resolution Water & Snow / Ice (HR-WSI)  
+  - High Resolution Vegetation Phenology & Productivity (HR-VPP)
   - High Resolution Layers: Grasslands  
 ---
 
@@ -211,6 +212,13 @@ parseo assemble \
   prefix=CLMS_WSI product=WIC pixel_spacing=020m tile_id=T33WXP \
   sensing_datetime=20201024T103021 platform=S2B processing_baseline=V100 file_id=WIC extension=tif
 # -> CLMS_WSI_WIC_020m_T33WXP_20201024T103021_S2B_V100_WIC.tif
+```
+
+# Example: CLMS HR-VPP product (first field: prefix)
+parseo assemble \
+  prefix=CLMS_VPP product=FAPAR resolution=100m tile_id=T32TNS \
+  start_date=20210101 end_date=20210110 version=V100 file_id=FAPAR extension=tif
+# -> CLMS_VPP_FAPAR_100m_T32TNS_20210101_20210110_V100_FAPAR.tif
 ```
 
 ---

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/fapar_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/fapar_filename_v0_0_0.json
@@ -1,0 +1,22 @@
+{
+  "schema_id": "copernicus:clms:hr-vpp:fapar",
+  "schema_version": "0.0.0",
+  "stac_version": "1.1.0",
+  "stac_extensions": ["raster", "eo"],
+  "description": "CLMS HR-VPP Fraction of Absorbed Photosynthetically Active Radiation product filename.",
+  "fields": {
+    "prefix": {"type": "string", "enum": ["CLMS_VPP"], "description": "Constant prefix"},
+    "product": {"type": "string", "enum": ["FAPAR"], "description": "Product code"},
+    "resolution": {"type": "string", "enum": ["100m"], "description": "Spatial resolution"},
+    "tile_id": {"type": "string", "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$", "description": "UTM tile identifier"},
+    "start_date": {"type": "string", "pattern": "^\\d{8}$", "description": "Start date (YYYYMMDD)"},
+    "end_date": {"type": "string", "pattern": "^\\d{8}$", "description": "End date (YYYYMMDD)"},
+    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
+    "file_id": {"type": "string", "enum": ["FAPAR", "MTD"], "description": "File identifier"},
+    "extension": {"type": "string", "enum": ["tif", "xml"], "description": "File extension without leading dot"}
+  },
+  "template": "{prefix}_{product}_{resolution}_{tile_id}_{start_date}_{end_date}_{version}_{file_id}[.{extension}]",
+  "examples": [
+    "CLMS_VPP_FAPAR_100m_T32TNS_20210101_20210110_V100_FAPAR.tif"
+  ]
+}

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/index.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/index.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "family": "HR-VPP",
+    "versions": [
+        {
+            "file": "fapar_filename_v0_0_0.json",
+            "version": "0.0.0",
+            "status": "current"
+        }
+    ]
+}

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -37,3 +37,38 @@ def test_assemble_auto_wic_schema():
     }
     result = assemble_auto(fields)
     assert result == "CLMS_WSI_WIC_020m_T33WXP_20201024T103021_S2B_V100_WIC.tif"
+
+def test_assemble_clms_fapar_schema():
+    schema = (
+        Path(__file__).resolve().parents[1]
+        / "src/parseo/schemas/copernicus/clms/hr-vpp/fapar_filename_v0_0_0.json"
+    )
+    fields = {
+        "prefix": "CLMS_VPP",
+        "product": "FAPAR",
+        "resolution": "100m",
+        "tile_id": "T32TNS",
+        "start_date": "20210101",
+        "end_date": "20210110",
+        "version": "V100",
+        "file_id": "FAPAR",
+        "extension": "tif",
+    }
+    result = assemble(schema, fields)
+    assert result == "CLMS_VPP_FAPAR_100m_T32TNS_20210101_20210110_V100_FAPAR.tif"
+
+
+def test_assemble_auto_fapar_schema():
+    fields = {
+        "prefix": "CLMS_VPP",
+        "product": "FAPAR",
+        "resolution": "100m",
+        "tile_id": "T32TNS",
+        "start_date": "20210101",
+        "end_date": "20210110",
+        "version": "V100",
+        "file_id": "FAPAR",
+        "extension": "tif",
+    }
+    result = assemble_auto(fields)
+    assert result == "CLMS_VPP_FAPAR_100m_T32TNS_20210101_20210110_V100_FAPAR.tif"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,6 +30,27 @@ def test_cli_assemble_success(capsys):
     )
 
 
+def test_cli_assemble_fapar_success(capsys):
+    sys.argv = [
+        'parseo',
+        'assemble',
+        'prefix=CLMS_VPP',
+        'product=FAPAR',
+        'resolution=100m',
+        'tile_id=T32TNS',
+        'start_date=20210101',
+        'end_date=20210110',
+        'version=V100',
+        'file_id=FAPAR',
+        'extension=tif',
+    ]
+    assert cli.main() == 0
+    captured = capsys.readouterr()
+    assert (
+        captured.out.strip()
+        == 'CLMS_VPP_FAPAR_100m_T32TNS_20210101_20210110_V100_FAPAR.tif'
+    )
+
 def test_cli_assemble_missing_assembler(monkeypatch):
     real_import = builtins.__import__
 


### PR DESCRIPTION
## Summary
- add HR-VPP FAPAR filename schema with template and index
- cover new schema with assembler and CLI tests
- document HR-VPP usage and supported product list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aa37cc29588327952d58ac30affc8f