### PR TITLE
Add HR-VPP ST PPI filename schema and tests

### DIFF
--- a/src/parseo/schemas/copernicus/clms/hr-vpp/index.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/index.json
@@ -6,6 +6,11 @@
             "file": "fapar_filename_v0_0_0.json",
             "version": "0.0.0",
             "status": "current"
+        },
+        {
+            "file": "st_filename_v0_0_0.json",
+            "version": "0.0.0",
+            "status": "current"
         }
     ]
 }

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/st_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/st_filename_v0_0_0.json
@@ -1,0 +1,21 @@
+{
+  "schema_id": "copernicus:clms:hr-vpp:st",
+  "schema_version": "0.0.0",
+  "stac_version": "1.1.0",
+  "stac_extensions": ["raster", "eo"],
+  "description": "CLMS HR-VPP Seasonal Trajectories Plant Phenology Index product filename.",
+  "fields": {
+    "prefix": {"type": "string", "enum": ["ST"], "description": "Constant prefix"},
+    "timestamp": {"type": "string", "pattern": "^\\d{8}T\\d{6}$", "description": "Acquisition timestamp (YYYYMMDDTHHMMSS)"},
+    "sensor": {"type": "string", "enum": ["S2"], "description": "Sensor platform"},
+    "tile_id": {"type": "string", "pattern": "^[EW]\\d{2}[NS]\\d{2}-\\d{5}$", "description": "Regional tile identifier"},
+    "resolution": {"type": "string", "pattern": "^\\d{3}m$", "description": "Spatial resolution"},
+    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
+    "product": {"type": "string", "enum": ["PPI"], "description": "Product code"},
+    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+  },
+  "template": "{prefix}_{timestamp}_{sensor}_{tile_id}_{resolution}_{version}_{product}[.{extension}]",
+  "examples": [
+    "ST_20240101T123045_S2_E15N45-01234_010m_V100_PPI.tif"
+  ]
+}

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -87,3 +87,37 @@ def test_assemble_auto_fapar_schema():
     }
     result = assemble_auto(fields)
     assert result == "CLMS_VPP_FAPAR_100m_T32TNS_20210101_20210110_V100_FAPAR.tif"
+
+
+def test_assemble_clms_st_schema():
+    schema = (
+        Path(__file__).resolve().parents[1]
+        / "src/parseo/schemas/copernicus/clms/hr-vpp/st_filename_v0_0_0.json"
+    )
+    fields = {
+        "prefix": "ST",
+        "timestamp": "20240101T123045",
+        "sensor": "S2",
+        "tile_id": "E15N45-01234",
+        "resolution": "010m",
+        "version": "V100",
+        "product": "PPI",
+        "extension": "tif",
+    }
+    result = assemble(schema, fields)
+    assert result == "ST_20240101T123045_S2_E15N45-01234_010m_V100_PPI.tif"
+
+
+def test_assemble_auto_st_schema():
+    fields = {
+        "prefix": "ST",
+        "timestamp": "20231231T000000",
+        "sensor": "S2",
+        "tile_id": "W05S20-98765",
+        "resolution": "030m",
+        "version": "V101",
+        "product": "PPI",
+        "extension": "tif",
+    }
+    result = assemble_auto(fields)
+    assert result == "ST_20231231T000000_S2_W05S20-98765_030m_V101_PPI.tif"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -113,3 +113,24 @@ def test_modis_example():
     assert res.fields["collection"] == "006"
     assert res.fields["proc_date"] == "2021132234506"
     assert res.fields["extension"] == "hdf"
+
+
+def test_hrvpp_st_example():
+    name = "ST_20240101T123045_S2_E15N45-01234_010m_V100_PPI.tif"
+    res = parse_auto(name)
+    assert res is not None
+    assert res.fields["prefix"] == "ST"
+    assert res.fields["timestamp"] == "20240101T123045"
+    assert res.fields["sensor"] == "S2"
+    assert res.fields["tile_id"] == "E15N45-01234"
+    assert res.fields["resolution"] == "010m"
+    assert res.fields["version"] == "V100"
+    assert res.fields["product"] == "PPI"
+    assert res.fields["extension"] == "tif"
+
+
+def test_hrvpp_st_variant():
+    name = "ST_20231231T000000_S2_W05S20-98765_030m_V101_PPI.tif"
+    res = parse_auto(name)
+    assert res.fields["tile_id"] == "W05S20-98765"
+    assert res.fields["version"] == "V101"


### PR DESCRIPTION
## Summary
- add Seasonal Trajectories (PPI) filename schema under HR-VPP
- register the schema in HR-VPP index
- test parsing and assembling Seasonal Trajectories filenames

## Testing
- `pre-commit run --files src/parseo/schemas/copernicus/clms/hr-vpp/st_filename_v0_0_0.json src/parseo/schemas/copernicus/clms/hr-vpp/index.json tests/test_assembler.py tests/test_parser.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: Cannot connect to proxy)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa3f78d73c8327b1c292693056435e