### PR TITLE
Add CLMS dataset catalog scraper and CLI command

### DIFF
--- a/src/parseo/cli.py
+++ b/src/parseo/cli.py
@@ -26,6 +26,12 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     p_info = sp.add_parser("schema-info", help="Show details for a mission family")
     p_info.add_argument("family", help="Mission family name, e.g. 'S2'")
 
+    # list-clms-products
+    sp.add_parser(
+        "list-clms-products",
+        help="List product names available in the CLMS dataset catalog",
+    )
+
     # assemble
     p_asm = sp.add_parser(
         "assemble",
@@ -146,6 +152,15 @@ def main(argv: List[str] | None = None) -> int:
         except KeyError as e:
             raise SystemExit(str(e))
         print(json.dumps(info, indent=2, ensure_ascii=False))
+        return 0
+
+    if args.cmd == "list-clms-products":
+        try:
+            from parseo.clms_catalog import fetch_clms_products
+        except Exception as exc:  # pragma: no cover - import-time failures
+            raise SystemExit(f"Failed to load CLMS catalog scraper: {exc}")
+        for name in fetch_clms_products():
+            print(name)
         return 0
 
     if args.cmd == "assemble":

--- a/src/parseo/clms_catalog.py
+++ b/src/parseo/clms_catalog.py
@@ -1,0 +1,76 @@
+"""Utilities to discover Copernicus Land Monitoring Service (CLMS) products.
+
+This module provides a tiny HTML scraper for the public CLMS dataset
+catalog (https://land.copernicus.eu/en/dataset-catalog).  It exposes two
+functions:
+
+- :func:`parse_html` which extracts dataset titles from a HTML page.
+- :func:`fetch_clms_products` which downloads the catalog page and returns
+  the list of dataset names.
+
+The scraper is intentionally lightweight and relies solely on the Python
+standard library, making it suitable for offline environments.  Network
+access is only required when calling :func:`fetch_clms_products`.
+"""
+from __future__ import annotations
+
+from html.parser import HTMLParser
+from typing import Iterable, List
+from urllib.request import urlopen
+
+DATASET_CATALOG_URL = "https://land.copernicus.eu/en/dataset-catalog"
+
+
+class _DatasetTitleParser(HTMLParser):
+    """Internal helper to extract dataset titles from the catalog HTML."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._capture = False
+        self.titles: List[str] = []
+
+    def handle_starttag(self, tag: str, attrs: Iterable[tuple[str, str | None]]) -> None:
+        if tag == "h2":
+            attrs_dict = dict(attrs)
+            css = attrs_dict.get("class", "") or ""
+            if "dataset-title" in css:
+                self._capture = True
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "h2" and self._capture:
+            self._capture = False
+
+    def handle_data(self, data: str) -> None:
+        if self._capture:
+            text = data.strip()
+            if text:
+                self.titles.append(text)
+
+
+def parse_html(html: str) -> List[str]:
+    """Parse raw HTML from the CLMS catalog and return dataset titles."""
+    parser = _DatasetTitleParser()
+    parser.feed(html)
+    # Deduplicate while preserving order
+    seen = set()
+    out: List[str] = []
+    for title in parser.titles:
+        if title not in seen:
+            seen.add(title)
+            out.append(title)
+    return out
+
+
+def fetch_clms_products(url: str = DATASET_CATALOG_URL) -> List[str]:
+    """Fetch the CLMS dataset catalog and return all product titles.
+
+    Parameters
+    ----------
+    url:
+        Optional catalog URL. The default points to the official CLMS
+        dataset catalog.
+    """
+    with urlopen(url) as resp:  # noqa: S310 - controlled URL
+        charset = resp.headers.get_content_charset() or "utf-8"
+        html = resp.read().decode(charset, "replace")
+    return parse_html(html)

--- a/tests/test_clms_catalog.py
+++ b/tests/test_clms_catalog.py
@@ -1,0 +1,12 @@
+from parseo.clms_catalog import parse_html
+
+
+def test_parse_html_extracts_titles():
+    html = """
+    <html><body>
+    <h2 class='dataset-title'>Product A</h2>
+    <h2 class='dataset-title'>Product B</h2>
+    <h2 class='dataset-title'>Product A</h2>
+    </body></html>
+    """
+    assert parse_html(html) == ["Product A", "Product B"]


### PR DESCRIPTION
## Summary
- add lightweight HTML parser to list Copernicus Land Monitoring Service dataset names
- expose new `list-clms-products` CLI command that prints catalog entries
- cover HTML parser with a unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa4603a2ac83278008195c623d9a8f