### PR TITLE
Add configurable STAC endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,21 @@ uvicorn main:app --reload
 The interactive page lets you call `/parse` and `/assemble` directly from the
 browser to verify your API.
 
+### Sample filenames from a STAC collection
+
+The ``stac-sample`` subcommand prints a few asset filenames from a STAC
+collection. The STAC API root must always be provided via ``--stac-url``:
+
+```bash
+parseo stac-sample S2 --samples 3 --stac-url https://catalogue.dataspace.copernicus.eu/stac/
+```
+
+A different STAC service can be targeted by supplying its URL:
+
+```bash
+parseo stac-sample my-collection --samples 2 --stac-url https://stac.example.com/
+```
+
 ---
 
 ## Command Line Interface

--- a/src/parseo/cli.py
+++ b/src/parseo/cli.py
@@ -7,6 +7,7 @@ import sys
 from typing import Any, Dict, List
 
 from parseo.parser import parse_auto, describe_schema, list_schemas  # parser helpers
+from parseo.stac_dataspace import sample_collection_filenames
 
 
 # ---------- small utilities ----------
@@ -30,6 +31,21 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     sp.add_parser(
         "list-clms-products",
         help="List product names available in the CLMS dataset catalog",
+    )
+
+    # stac-sample
+    p_stac = sp.add_parser(
+        "stac-sample",
+        help="Print sample asset filenames from a STAC collection",
+    )
+    p_stac.add_argument("collection", help="STAC collection ID")
+    p_stac.add_argument(
+        "--samples", type=int, default=5, help="Number of filenames to list"
+    )
+    p_stac.add_argument(
+        "--stac-url",
+        required=True,
+        help="Base URL of the STAC API",
     )
 
     # assemble
@@ -161,6 +177,13 @@ def main(argv: List[str] | None = None) -> int:
             raise SystemExit(f"Failed to load CLMS catalog scraper: {exc}")
         for name in fetch_clms_products():
             print(name)
+        return 0
+
+    if args.cmd == "stac-sample":
+        for fn in sample_collection_filenames(
+            args.collection, args.samples, base_url=args.stac_url
+        ):
+            print(fn)
         return 0
 
     if args.cmd == "assemble":

--- a/src/parseo/stac_dataspace.py
+++ b/src/parseo/stac_dataspace.py
@@ -1,0 +1,58 @@
+"""Helpers for querying STAC APIs.
+
+The Copernicus Data Space Ecosystem STAC root URL is available as
+``CDSE_STAC_URL`` for convenience but is not used as a default.  All helper
+functions require explicitly passing the ``base_url`` of the STAC service.
+"""
+from __future__ import annotations
+
+from typing import Iterable, List
+from urllib.parse import urljoin
+import urllib.request
+import json
+import itertools
+
+CDSE_STAC_URL = "https://catalogue.dataspace.copernicus.eu/stac/"
+
+
+def _read_json(url: str) -> dict:
+    with urllib.request.urlopen(url) as resp:  # type: ignore[call-arg]
+        return json.load(resp)
+
+
+def list_collections(base_url: str) -> List[str]:
+    """Return available collection IDs from the STAC API."""
+    data = _read_json(urljoin(base_url, "collections"))
+    return [c["id"] for c in data.get("collections", [])]
+
+
+def iter_asset_filenames(
+    collection_id: str,
+    *,
+    base_url: str,
+    limit: int = 100,
+) -> Iterable[str]:
+    """Yield asset filenames from items of a collection."""
+    url = urljoin(base_url, f"collections/{collection_id}/items?limit={limit}")
+    data = _read_json(url)
+    for feat in data.get("features", []):
+        assets = feat.get("assets", {})
+        for asset in assets.values():
+            href = asset.get("href")
+            if not href:
+                continue
+            yield href.rstrip("/").split("/")[-1]
+
+
+def sample_collection_filenames(
+    collection_id: str,
+    samples: int = 5,
+    *,
+    base_url: str,
+) -> List[str]:
+    """Return ``samples`` filenames from the given collection."""
+    return list(
+        itertools.islice(
+            iter_asset_filenames(collection_id, base_url=base_url), samples
+        )
+    )

--- a/tests/test_stac_dataspace.py
+++ b/tests/test_stac_dataspace.py
@@ -1,0 +1,51 @@
+import pytest
+import parseo.stac_dataspace as sd
+
+
+def test_list_collections_custom_base_url(monkeypatch):
+    urls = []
+
+    def fake_read_json(url):
+        urls.append(url)
+        return {"collections": [{"id": "abc"}]}
+
+    monkeypatch.setattr(sd, "_read_json", fake_read_json)
+    out = sd.list_collections(base_url="http://x/")
+    assert urls == ["http://x/collections"]
+    assert out == ["abc"]
+
+
+def test_iter_asset_filenames_custom_base_url(monkeypatch):
+    urls = []
+
+    def fake_read_json(url):
+        urls.append(url)
+        return {
+            "features": [
+                {"assets": {"a": {"href": "http://files/file1.tif"}}}
+            ]
+        }
+
+    monkeypatch.setattr(sd, "_read_json", fake_read_json)
+    out = list(sd.iter_asset_filenames("C1", base_url="http://y/", limit=1))
+    assert urls == ["http://y/collections/C1/items?limit=1"]
+    assert out == ["file1.tif"]
+
+
+def test_sample_collection_filenames_custom_base_url(monkeypatch):
+    called = {}
+
+    def fake_iter(collection_id, *, base_url, limit=100):
+        called["collection"] = collection_id
+        called["base_url"] = base_url
+        return iter(["f1", "f2", "f3"])
+
+    monkeypatch.setattr(sd, "iter_asset_filenames", fake_iter)
+    res = sd.sample_collection_filenames("COL", 2, base_url="http://z/")
+    assert called == {"collection": "COL", "base_url": "http://z/"}
+    assert res == ["f1", "f2"]
+
+
+def test_list_collections_requires_base_url():
+    with pytest.raises(TypeError):
+        sd.list_collections()


### PR DESCRIPTION
## Summary
- require explicit STAC base URL for STAC helpers
- require `--stac-url` option in CLI and document its usage
- extend unit tests for custom STAC endpoints

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aadb84648c832788460ace46f8c661