### PR TITLE
Add STAC collection alias mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,12 @@ collection. The STAC API root must always be provided via ``--stac-url``
 parseo stac-sample SENTINEL2_L2A --samples 3 --stac-url https://catalogue.dataspace.copernicus.eu/stac
 ```
 
+Known collection aliases are automatically mapped to their official STAC IDs:
+
+| Alias | STAC ID |
+|-------|---------|
+| `SENTINEL2_L2A` | `sentinel-2-l2a` |
+
 A different STAC service can be targeted by supplying its URL:
 
 ```bash

--- a/src/parseo/stac_dataspace.py
+++ b/src/parseo/stac_dataspace.py
@@ -15,6 +15,18 @@ import itertools
 CDSE_STAC_URL = "https://catalogue.dataspace.copernicus.eu/stac/"
 
 
+# Mapping of common collection aliases to their official STAC IDs.
+# Keys are case-insensitive aliases as they might appear in user commands.
+STAC_ID_ALIASES: dict[str, str] = {
+    "SENTINEL2_L2A": "sentinel-2-l2a",
+}
+
+
+def _norm_collection_id(collection_id: str) -> str:
+    """Return the official STAC collection ID for ``collection_id``."""
+    return STAC_ID_ALIASES.get(collection_id.upper(), collection_id)
+
+
 def _norm_base(base_url: str) -> str:
     """Return ``base_url`` with exactly one trailing slash."""
     return base_url.rstrip("/") + "/"
@@ -57,7 +69,12 @@ def sample_collection_filenames(
     *,
     base_url: str,
 ) -> list[str]:
-    """Return ``samples`` filenames from the given collection."""
+    """Return ``samples`` filenames from the given collection.
+
+    ``collection_id`` may be the official STAC ID or any alias defined in
+    :data:`STAC_ID_ALIASES`.
+    """
+    collection_id = _norm_collection_id(collection_id)
     return list(
         itertools.islice(
             iter_asset_filenames(collection_id, base_url=base_url), samples

--- a/tests/test_stac_dataspace.py
+++ b/tests/test_stac_dataspace.py
@@ -46,6 +46,24 @@ def test_sample_collection_filenames_custom_base_url(monkeypatch):
     assert res == ["f1", "f2"]
 
 
+def test_sample_collection_filenames_alias(monkeypatch):
+    calls = []
+
+    def fake_iter(collection_id, *, base_url, limit=100):
+        calls.append(collection_id)
+        return iter(["a", "b"])
+
+    monkeypatch.setattr(sd, "iter_asset_filenames", fake_iter)
+    alias_res = sd.sample_collection_filenames(
+        "SENTINEL2_L2A", base_url="http://z"
+    )
+    official_res = sd.sample_collection_filenames(
+        "sentinel-2-l2a", base_url="http://z"
+    )
+    assert alias_res == official_res == ["a", "b"]
+    assert calls == ["sentinel-2-l2a", "sentinel-2-l2a"]
+
+
 def test_list_collections_requires_base_url():
     with pytest.raises(TypeError):
         sd.list_collections()


### PR DESCRIPTION
## Summary
- add `STAC_ID_ALIASES` for mapping common collection aliases to official STAC IDs
- normalize `collection_id` in `sample_collection_filenames`
- document supported alias mapping and test alias vs. official ID

## Testing
- `pytest tests/test_stac_dataspace.py`
- `pre-commit run --files README.md src/parseo/stac_dataspace.py tests/test_stac_dataspace.py` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ab22d6e61c83278b33478d7e842361