### PR TITLE
Support recursive STAC collection sampling

### DIFF
--- a/src/parseo/cli.py
+++ b/src/parseo/cli.py
@@ -196,10 +196,13 @@ def main(argv: List[str] | None = None) -> int:
         return 0
 
     if args.cmd == "stac-sample":
-        for fn in sample_collection_filenames(
+        samples = sample_collection_filenames(
             args.collection, args.samples, base_url=args.stac_url
-        ):
-            print(fn)
+        )
+        for cid in sorted(samples):
+            print(f"{cid}:")
+            for fn in samples[cid]:
+                print(f"  {fn}")
         return 0
 
     if args.cmd == "assemble":

--- a/src/parseo/stac_dataspace.py
+++ b/src/parseo/stac_dataspace.py
@@ -76,20 +76,62 @@ def iter_asset_filenames(
             yield href.rstrip("/").split("/")[-1]
 
 
+def iter_collection_tree(
+    collection_id: str,
+    *,
+    base_url: str,
+    limit: int = 100,
+) -> Iterable[tuple[str, str]]:
+    """Yield ``(collection_id, filename)`` pairs for all leaf collections.
+
+    The function follows ``links`` with ``rel="child"`` starting from
+    ``collection_id`` until it reaches leaf collections.  For each leaf it
+    yields filenames from :func:`iter_asset_filenames`.
+    """
+    base = _norm_base(base_url)
+    url = urljoin(base, f"collections/{collection_id}")
+    try:
+        data = _read_json(url)
+    except urllib.error.HTTPError as err:
+        if err.code == 404:
+            raise SystemExit(
+                f"Collection '{collection_id}' not found at {base}. "
+                "Use `parseo stac-sample <collection> --stac-url <url>` with a valid collection ID."
+            ) from err
+        raise SystemExit(f"HTTP error {err.code} for {err.geturl()}") from err
+
+    children = [
+        link.get("href", "").rstrip("/").split("/")[-1]
+        for link in data.get("links", [])
+        if link.get("rel") == "child"
+    ]
+
+    if children:
+        for child in children:
+            yield from iter_collection_tree(child, base_url=base, limit=limit)
+    else:
+        for fn in itertools.islice(
+            iter_asset_filenames(collection_id, base_url=base, limit=limit), limit
+        ):
+            yield collection_id, fn
+
+
 def sample_collection_filenames(
     collection_id: str,
     samples: int = 5,
     *,
     base_url: str,
-) -> list[str]:
-    """Return ``samples`` filenames from the given collection.
+) -> dict[str, list[str]]:
+    """Return ``samples`` filenames for each leaf collection.
 
     ``collection_id`` may be the official STAC ID or any alias defined in
-    :data:`STAC_ID_ALIASES`.
+    :data:`STAC_ID_ALIASES`.  When ``collection_id`` has child collections, a
+    sample is collected from each leaf.
     """
     collection_id = _norm_collection_id(collection_id)
-    return list(
-        itertools.islice(
-            iter_asset_filenames(collection_id, base_url=base_url), samples
-        )
-    )
+    out: dict[str, list[str]] = {}
+    for cid, fn in iter_collection_tree(collection_id, base_url=base_url, limit=samples):
+        lst = out.setdefault(cid, [])
+        if len(lst) < samples:
+            lst.append(fn)
+    return out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -128,7 +128,7 @@ def test_cli_stac_sample_custom_url(monkeypatch, capsys):
         calls["collection"] = collection
         calls["samples"] = samples
         calls["base_url"] = base_url
-        return ["a", "b"]
+        return {"C1": ["a"], "C2": ["b"]}
 
     monkeypatch.setattr(cli, "sample_collection_filenames", fake_sample)
     sys.argv = [
@@ -142,7 +142,7 @@ def test_cli_stac_sample_custom_url(monkeypatch, capsys):
     ]
     assert cli.main() == 0
     out = capsys.readouterr().out.splitlines()
-    assert out == ["a", "b"]
+    assert out == ["C1:", "  a", "C2:", "  b"]
     assert calls == {
         "collection": "COL",
         "samples": 2,

--- a/tests/test_stac_dataspace.py
+++ b/tests/test_stac_dataspace.py
@@ -36,33 +36,68 @@ def test_iter_asset_filenames_custom_base_url(monkeypatch):
 def test_sample_collection_filenames_custom_base_url(monkeypatch):
     called = {}
 
-    def fake_iter(collection_id, *, base_url, limit=100):
+    def fake_iter_tree(collection_id, *, base_url, limit):
         called["collection"] = collection_id
         called["base_url"] = base_url
-        return iter(["f1", "f2", "f3"])
+        called["limit"] = limit
+        yield (collection_id, "f1")
+        yield (collection_id, "f2")
+        yield (collection_id, "f3")
 
-    monkeypatch.setattr(sd, "iter_asset_filenames", fake_iter)
+    monkeypatch.setattr(sd, "iter_collection_tree", fake_iter_tree)
     res = sd.sample_collection_filenames("COL", 2, base_url="http://z")
-    assert called == {"collection": "COL", "base_url": "http://z"}
-    assert res == ["f1", "f2"]
+    assert called == {
+        "collection": "COL",
+        "base_url": "http://z",
+        "limit": 2,
+    }
+    assert res == {"COL": ["f1", "f2"]}
 
 
 def test_sample_collection_filenames_alias(monkeypatch):
     calls = []
 
-    def fake_iter(collection_id, *, base_url, limit=100):
+    def fake_iter_tree(collection_id, *, base_url, limit):
         calls.append(collection_id)
-        return iter(["a", "b"])
+        yield (collection_id, "a")
+        yield (collection_id, "b")
 
-    monkeypatch.setattr(sd, "iter_asset_filenames", fake_iter)
+    monkeypatch.setattr(sd, "iter_collection_tree", fake_iter_tree)
     alias_res = sd.sample_collection_filenames(
         "SENTINEL2_L2A", base_url="http://z"
     )
     official_res = sd.sample_collection_filenames(
         "sentinel-2-l2a", base_url="http://z"
     )
-    assert alias_res == official_res == ["a", "b"]
+    assert alias_res == official_res == {"sentinel-2-l2a": ["a", "b"]}
     assert calls == ["sentinel-2-l2a", "sentinel-2-l2a"]
+
+
+def test_sample_collection_filenames_nested(monkeypatch):
+    """Ensure nested child collections are sampled."""
+
+    collections = {
+        "ROOT": [{"rel": "child", "href": "collections/C1"}, {"rel": "child", "href": "collections/C2"}],
+        "C1": [],
+        "C2": [{"rel": "child", "href": "collections/C3"}],
+        "C3": [],
+    }
+
+    def fake_read_json(url):
+        cid = url.split("/")[-1]
+        return {"links": collections[cid]}
+
+    monkeypatch.setattr(sd, "_read_json", fake_read_json)
+
+    def fake_iter_asset(collection_id, *, base_url, limit=100):
+        return iter({
+            "C1": ["a1", "a2"],
+            "C3": ["c1", "c2"],
+        }[collection_id])
+
+    monkeypatch.setattr(sd, "iter_asset_filenames", fake_iter_asset)
+    res = sd.sample_collection_filenames("ROOT", 1, base_url="http://x")
+    assert res == {"C1": ["a1"], "C3": ["c1"]}
 
 
 def test_list_collections_requires_base_url():


### PR DESCRIPTION
## Summary
- add `iter_collection_tree` to recursively traverse STAC collections and gather asset filenames from leaf collections
- return per-collection filename samples and update CLI to group output by subcollection
- test sampling across nested collections and updated CLI behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab2fe517408327b7c992510a0f70be