### PR TITLE
Document scrape_catalog STAC helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,9 +165,9 @@ browser to verify your API.
 
 ---
 
-## STAC metadata (not functional yet!)
+## STAC helpers
 
-Since filenames often reflect associated metadata or directory structures, `parsEO` aligns with STAC naming conventions whenever possible. The package provides helper functions to derive filename schemas from STAC catalogs. Although filenames usually precede catalog creation, future development aims for a bidirectional information flow (STAC ↔ filename). At present, the focus remains on collecting filename schemas supported by `parsEO`.
+Filenames often reflect associated metadata or directory structures, so `parsEO` aligns with STAC naming conventions whenever possible. The package ships with small utilities to interact with STAC APIs and catalogs, including helpers to list collections, sample asset filenames, and traverse catalogs stored on disk.
 
 Use the ``list-stac-collections`` subcommand to list collection IDs exposed by a
 STAC API. The STAC root URL must be supplied via ``--stac-url``:
@@ -248,6 +248,28 @@ for cid in stac_scraper.list_collections(stac_url):
 
 This functionality depends on the ``pystac-client`` and ``requests``
 packages being available at runtime.
+
+### Scrape a STAC catalog
+
+``parseo.scrape_catalog`` is a lightweight helper that walks a STAC catalog or
+collection and extracts basic metadata for each data asset using only the
+Python standard library.
+
+```python
+from parseo import scrape_catalog
+
+# Collect filenames and associated metadata from a catalog on disk
+entries = scrape_catalog("/path/to/catalog", limit=2)
+for e in entries:
+    print(e["filename"], e.get("id"), e.get("tile"))
+```
+
+Each entry includes the asset filename plus any of the fields ``id``,
+``product_type``, ``datetime``, ``tile`` and ``orbit`` discovered in adjacent
+JSON or XML metadata files.
+
+From the command line, related STAC utilities are available via the
+``list-stac-collections`` and ``stac-sample`` subcommands.
 
 ---
 

--- a/src/parseo/stac_scraper.py
+++ b/src/parseo/stac_scraper.py
@@ -272,7 +272,6 @@ def scrape_catalog(root: str | Path, *, limit: int = 100) -> list[dict[str, str]
 def sample_collection_filenames(*args, **kwargs) -> dict[str, list[str]]:  # pragma: no cover
     """Deprecated placeholder for backward compatibility.
 
-    The original implementation relied on the removed ``stac_dataspace`` module.
     Users should call :func:`scrape_catalog` instead.
     """
     raise SystemExit("sample_collection_filenames is no longer supported")


### PR DESCRIPTION
## Summary
- clarify STAC helper utilities and provide scrape_catalog example
- mention related CLI subcommands for STAC operations
- drop leftover reference to removed stac_dataspace module

## Testing
- `pytest`
- `pre-commit run --files README.md src/parseo/stac_scraper.py` *(fails: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac68d315648327a4a4f744e67696d2