### PR TITLE
Add CCD schema and round-trip tests

### DIFF
--- a/src/parseo/schemas/copernicus/clms/ccd/ccd_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/ccd/ccd_filename_v1_0_0.json
@@ -1,0 +1,49 @@
+{
+  "schema_id": "copernicus:clms:ccd",
+  "schema_version": "1.0.0",
+  "stac_version": "1.1.0",
+  "stac_extensions": ["raster", "eo"],
+  "description": "Copernicus Land Monitoring Service CCD product filename.",
+  "fields": {
+    "reference_year": {
+      "type": "string",
+      "enum": ["2015", "2018"],
+      "description": "Reference year"
+    },
+    "resolution": {
+      "type": "string",
+      "enum": ["100m"],
+      "description": "Spatial resolution"
+    },
+    "aoi_code": {
+      "type": "string",
+      "pattern": "^E\\d{3}N\\d{3}$",
+      "description": "Area of interest code"
+    },
+    "epsg": {
+      "type": "string",
+      "pattern": "^0?3035$",
+      "description": "EPSG code"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^v\\d$",
+      "description": "Product version"
+    },
+    "tile": {
+      "type": "string",
+      "pattern": "^\\d$",
+      "description": "Tile number"
+    },
+    "extension": {
+      "type": "string",
+      "enum": ["tif"],
+      "description": "File extension without leading dot"
+    }
+  },
+  "template": "ccd_{reference_year}_{resolution}_{aoi_code}_{epsg}_{version}_{tile}[.{extension}]",
+  "examples": [
+    "ccd_2015_100m_E042N018_3035_v1_1.tif",
+    "ccd_2018_100m_E050N020_3035_v2_2.tif"
+  ]
+}

--- a/src/parseo/schemas/copernicus/clms/ccd/index.json
+++ b/src/parseo/schemas/copernicus/clms/ccd/index.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "family": "CCD",
+    "versions": [
+        {
+            "file": "ccd_filename_v1_0_0.json",
+            "version": "1.0.0",
+            "status": "current"
+        }
+    ]
+}

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from parseo import assemble, assemble_auto, clear_schema_cache
+from parseo import assemble, assemble_auto, clear_schema_cache, parse_auto
 
 
 def test_assemble_clms_fsc_schema():
@@ -216,3 +216,53 @@ def test_clear_schema_cache(tmp_path):
 
     clear_schema_cache()
     assert assemble(schema, fields) == "x-y"
+
+def test_assemble_clms_ccd_schema():
+    name = "ccd_2015_100m_E042N018_3035_v1_1.tif"
+    schema = (
+        Path(__file__).resolve().parents[1]
+        / "src/parseo/schemas/copernicus/clms/ccd/ccd_filename_v1_0_0.json"
+    )
+    fields = parse_auto(name).fields
+    result = assemble(schema, fields)
+    assert result == name
+
+
+def test_assemble_auto_ccd_schema():
+    fields = {
+        "reference_year": "2015",
+        "resolution": "100m",
+        "aoi_code": "E042N018",
+        "epsg": "3035",
+        "version": "v1",
+        "tile": "1",
+        "extension": "tif",
+    }
+    result = assemble_auto(fields)
+    assert result == "ccd_2015_100m_E042N018_3035_v1_1.tif"
+
+
+def test_assemble_clms_ccd_schema_2018():
+    name = "ccd_2018_100m_E050N020_3035_v2_2.tif"
+    schema = (
+        Path(__file__).resolve().parents[1]
+        / "src/parseo/schemas/copernicus/clms/ccd/ccd_filename_v1_0_0.json"
+    )
+    fields = parse_auto(name).fields
+    result = assemble(schema, fields)
+    assert result == name
+
+
+def test_assemble_auto_ccd_schema_2018():
+    fields = {
+        "reference_year": "2018",
+        "resolution": "100m",
+        "aoi_code": "E050N020",
+        "epsg": "3035",
+        "version": "v2",
+        "tile": "2",
+        "extension": "tif",
+    }
+    result = assemble_auto(fields)
+    assert result == "ccd_2018_100m_E050N020_3035_v2_2.tif"
+

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -134,3 +134,29 @@ def test_hrvpp_st_variant():
     res = parse_auto(name)
     assert res.fields["tile_id"] == "W05S20-98765"
     assert res.fields["version"] == "V101"
+
+def test_clms_ccd_example():
+    name = "ccd_2015_100m_E042N018_3035_v1_1.tif"
+    res = parse_auto(name)
+    assert res is not None
+    assert res.fields["reference_year"] == "2015"
+    assert res.fields["resolution"] == "100m"
+    assert res.fields["aoi_code"] == "E042N018"
+    assert res.fields["epsg"] == "3035"
+    assert res.fields["version"] == "v1"
+    assert res.fields["tile"] == "1"
+    assert res.fields["extension"] == "tif"
+
+
+def test_clms_ccd_example_2018():
+    name = "ccd_2018_100m_E050N020_3035_v2_2.tif"
+    res = parse_auto(name)
+    assert res is not None
+    assert res.fields["reference_year"] == "2018"
+    assert res.fields["resolution"] == "100m"
+    assert res.fields["aoi_code"] == "E050N020"
+    assert res.fields["epsg"] == "3035"
+    assert res.fields["version"] == "v2"
+    assert res.fields["tile"] == "2"
+    assert res.fields["extension"] == "tif"
+


### PR DESCRIPTION
## Summary
- add Copernicus Land Monitoring Service CCD schema and index
- define CCD filename fields and examples with template
- allow 2015 or 2018 reference years and ExxxNxxx AOI codes
- test parse and assemble round-trip for CCD names

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aca4dee3048327b39e7d5604c50606