### PR TITLE
Normalize STAC collection IDs and fix HRLVLCC schema prefix

### DIFF
--- a/src/parseo/schemas/copernicus/clms/hrlvlcc/hrlvlcc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrlvlcc/hrlvlcc_filename_v0_0_0.json
@@ -5,7 +5,7 @@
   "stac_extensions": ["raster", "eo"],
   "description": "CLMS HRL Vegetation & Land Cover Characteristics product filename.",
   "fields": {
-    "prefix": {"type": "string", "enum": ["CLMS_HRLVLCC"], "description": "Constant prefix"},
+    "prefix": {"type": "string", "enum": ["CLMS_HRLVLC"], "description": "Constant prefix"},
     "product": {
       "type": "string",
       "enum": ["IMD", "TCD", "FTY", "GRA", "SWF", "WAW"],

--- a/src/parseo/stac_scraper.py
+++ b/src/parseo/stac_scraper.py
@@ -18,13 +18,15 @@ def _norm_base(base_url: str) -> str:
     return base_url.rstrip("/") + "/"
 
 # Mapping of common collection aliases to their official STAC IDs.
-# Keys and values are uppercase so lookups can be performed on normalized
-# ``str.upper`` versions of user supplied IDs.
+#
+# Lookups are performed case-insensitively by normalizing the user supplied
+# identifier with ``str.upper`` and checking against these keys.  The mapped
+# values retain the canonical casing required by the STAC API.
 STAC_ID_ALIASES: dict[str, str] = {
-    "SENTINEL2_L2A": "SENTINEL-2-L2A",
-    "S2_L2A": "SENTINEL-2-L2A",
-    "SENTINEL2_L1C": "SENTINEL-2-L1C",
-    "S2_L1C": "SENTINEL-2-L1C",
+    "SENTINEL2_L2A": "sentinel-2-l2a",
+    "S2_L2A": "sentinel-2-l2a",
+    "SENTINEL2_L1C": "sentinel-2-l1c",
+    "S2_L1C": "sentinel-2-l1c",
 }
 
 
@@ -47,8 +49,8 @@ def _temporal_midpoint(
 
 def _norm_collection_id(collection_id: str) -> str:
     """Return the official STAC collection ID for ``collection_id``."""
-    cid = collection_id.upper()
-    return STAC_ID_ALIASES.get(cid, cid)
+    cid_upper = collection_id.upper()
+    return STAC_ID_ALIASES.get(cid_upper, collection_id)
 
 def list_collections_client(base_url: str, *, deep: bool = False) -> list[str]:
     """Return collection IDs from a STAC API using ``pystac-client``.

--- a/tests/test_stac_scraper.py
+++ b/tests/test_stac_scraper.py
@@ -13,10 +13,10 @@ stac_url = "http://base"
 @pytest.mark.parametrize(
     "alias, expected",
     [
-        ("sentinel-2-l2a", "SENTINEL-2-L2A"),
-        ("s2_l2a", "SENTINEL-2-L2A"),
-        ("sentinel-2-l1c", "SENTINEL-2-L1C"),
-        ("sentinel2_l1c", "SENTINEL-2-L1C"),
+        ("sentinel-2-l2a", "sentinel-2-l2a"),
+        ("s2_l2a", "sentinel-2-l2a"),
+        ("sentinel-2-l1c", "sentinel-2-l1c"),
+        ("sentinel2_l1c", "sentinel-2-l1c"),
     ],
 )
 def test_norm_collection_id_aliases(alias, expected):
@@ -84,7 +84,7 @@ def test_list_collections_alias(monkeypatch, base_url):
 
 @pytest.mark.parametrize("collections", [["s2_l2a"], "s2_l2a"])
 def test_search_stac_and_download(monkeypatch, tmp_path, collections):
-    FakeClientSearch.expected = ["SENTINEL-2-L2A"]
+    FakeClientSearch.expected = ["sentinel-2-l2a"]
 
     fake_pc = types.SimpleNamespace(Client=FakeClientSearch)
     monkeypatch.setitem(sys.modules, "pystac_client", fake_pc)


### PR DESCRIPTION
## Summary
- normalize STAC collection aliases to lowercase IDs
- adjust STAC scraper tests to new alias mapping
- correct CLMS HRLVLCC schema prefix enum

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acbd9e10cc8327af95883df90a7760