### PR TITLE
Add CLMS global CGLS schemas and update tests

### DIFF
--- a/src/parseo/schemas/copernicus/clms/cgls/fapar/fapar_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/cgls/fapar/fapar_filename_v0_0_0.json
@@ -1,0 +1,22 @@
+{
+  "schema_id": "copernicus:clms:cgls:fapar",
+  "schema_version": "0.0.0",
+  "stac_version": "1.1.0",
+  "stac_extensions": ["raster", "eo"],
+  "description": "CLMS CGLS FAPAR product filename.",
+  "fields": {
+    "prefix": {"type": "string", "enum": ["c_gls"], "description": "Constant prefix"},
+    "product": {"type": "string", "enum": ["FAPAR"], "description": "Product code"},
+    "resolution": {"type": "string", "enum": ["300", "1km"], "description": "Spatial resolution"},
+    "sensing_datetime": {"type": "string", "pattern": "^\\d{12}$", "description": "Acquisition datetime (UTC)"},
+    "region": {"type": "string", "pattern": "^[A-Z0-9-]+$", "description": "Region identifier"},
+    "sensor": {"type": "string", "pattern": "^[A-Z0-9-]+$", "description": "Sensor identifier"},
+    "version": {"type": "string", "pattern": "^V\\d+(?:\\.\\d+){1,2}$", "description": "Product version"},
+    "extension": {"type": "string", "enum": ["nc", "tif", "zip"], "description": "File extension without leading dot"}
+  },
+  "template": "{prefix}_{product}{resolution}_{sensing_datetime}_{region}[_{sensor}]_{version}[.{extension}]",
+  "examples": [
+    "c_gls_FAPAR300_202305150000_GLOBE_PROBAV_V1.1.1.nc",
+    "c_gls_FAPAR1km_202112250000_CEURO_PROBAV_V1.0.1.nc"
+  ]
+}

--- a/src/parseo/schemas/copernicus/clms/cgls/fapar/index.json
+++ b/src/parseo/schemas/copernicus/clms/cgls/fapar/index.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "family": "CGLS-FAPAR",
+    "versions": [
+        {
+            "file": "fapar_filename_v0_0_0.json",
+            "version": "0.0.0",
+            "status": "current"
+        }
+    ]
+}

--- a/src/parseo/schemas/copernicus/clms/cgls/lai/index.json
+++ b/src/parseo/schemas/copernicus/clms/cgls/lai/index.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "family": "CGLS-LAI",
+    "versions": [
+        {
+            "file": "lai_filename_v0_0_0.json",
+            "version": "0.0.0",
+            "status": "current"
+        }
+    ]
+}

--- a/src/parseo/schemas/copernicus/clms/cgls/lai/lai_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/cgls/lai/lai_filename_v0_0_0.json
@@ -1,0 +1,22 @@
+{
+  "schema_id": "copernicus:clms:cgls:lai",
+  "schema_version": "0.0.0",
+  "stac_version": "1.1.0",
+  "stac_extensions": ["raster", "eo"],
+  "description": "CLMS CGLS LAI product filename.",
+  "fields": {
+    "prefix": {"type": "string", "enum": ["c_gls"], "description": "Constant prefix"},
+    "product": {"type": "string", "enum": ["LAI"], "description": "Product code"},
+    "resolution": {"type": "string", "enum": ["300", "1km"], "description": "Spatial resolution"},
+    "sensing_datetime": {"type": "string", "pattern": "^\\d{12}$", "description": "Acquisition datetime (UTC)"},
+    "region": {"type": "string", "pattern": "^[A-Z0-9-]+$", "description": "Region identifier"},
+    "sensor": {"type": "string", "pattern": "^[A-Z0-9-]+$", "description": "Sensor identifier"},
+    "version": {"type": "string", "pattern": "^V\\d+(?:\\.\\d+){1,2}$", "description": "Product version"},
+    "extension": {"type": "string", "enum": ["nc", "tif", "zip"], "description": "File extension without leading dot"}
+  },
+  "template": "{prefix}_{product}{resolution}_{sensing_datetime}_{region}[_{sensor}]_{version}[.{extension}]",
+  "examples": [
+    "c_gls_LAI300_202307010000_GLOBE_PROBAV_V1.2.1.nc",
+    "c_gls_LAI1km_202104010000_EURO_PROBAV_V1.1.1.nc"
+  ]
+}

--- a/src/parseo/schemas/copernicus/clms/cgls/ndvi/index.json
+++ b/src/parseo/schemas/copernicus/clms/cgls/ndvi/index.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "family": "CGLS-NDVI",
+    "versions": [
+        {
+            "file": "ndvi_filename_v0_0_0.json",
+            "version": "0.0.0",
+            "status": "current"
+        }
+    ]
+}

--- a/src/parseo/schemas/copernicus/clms/cgls/ndvi/ndvi_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/cgls/ndvi/ndvi_filename_v0_0_0.json
@@ -1,0 +1,22 @@
+{
+  "schema_id": "copernicus:clms:cgls:ndvi",
+  "schema_version": "0.0.0",
+  "stac_version": "1.1.0",
+  "stac_extensions": ["raster", "eo"],
+  "description": "CLMS CGLS NDVI product filename.",
+  "fields": {
+    "prefix": {"type": "string", "enum": ["c_gls"], "description": "Constant prefix"},
+    "product": {"type": "string", "enum": ["NDVI"], "description": "Product code"},
+    "resolution": {"type": "string", "enum": ["300", "1km"], "description": "Spatial resolution"},
+    "sensing_datetime": {"type": "string", "pattern": "^\\d{12}$", "description": "Acquisition datetime (UTC)"},
+    "region": {"type": "string", "pattern": "^[A-Z0-9-]+$", "description": "Region identifier"},
+    "sensor": {"type": "string", "pattern": "^[A-Z0-9-]+$", "description": "Sensor identifier"},
+    "version": {"type": "string", "pattern": "^V\\d+(?:\\.\\d+){1,2}$", "description": "Product version"},
+    "extension": {"type": "string", "enum": ["nc", "tif", "zip"], "description": "File extension without leading dot"}
+  },
+  "template": "{prefix}_{product}{resolution}_{sensing_datetime}_{region}[_{sensor}]_{version}[.{extension}]",
+  "examples": [
+    "c_gls_NDVI300_202306050000_GLOBE_PROBAV_V2.2.1.nc",
+    "c_gls_NDVI1km_202106050000_EURO_PROBAV_V2.1.1.nc"
+  ]
+}

--- a/src/parseo/schemas/copernicus/clms/hrlvlcc/hrlvlcc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrlvlcc/hrlvlcc_filename_v0_0_0.json
@@ -5,7 +5,7 @@
   "stac_extensions": ["raster", "eo"],
   "description": "CLMS HRL Vegetation & Land Cover Characteristics product filename.",
   "fields": {
-    "prefix": {"type": "string", "enum": ["CLMS_HRLVLC"], "description": "Constant prefix"},
+    "prefix": {"type": "string", "enum": ["CLMS_HRLVLCC"], "description": "Constant prefix"},
     "product": {
       "type": "string",
       "enum": ["IMD", "TCD", "FTY", "GRA", "SWF", "WAW"],

--- a/src/parseo/schemas/copernicus/cz/cz_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/cz/cz_filename_v0_0_0.json
@@ -2,54 +2,16 @@
   "schema_id": "copernicus:cz",
   "schema_version": "0.0.0",
   "stac_version": "1.1.0",
-  "stac_extensions": [
-    "vector"
-  ],
+  "stac_extensions": ["vector"],
   "description": "Schema for CZ vector products.",
   "fields": {
-    "prefix": {
-      "type": "string",
-      "enum": [
-        "CZ"
-      ],
-      "description": "Constant prefix"
-    },
-      "year": {
-      "type": "string",
-      "enum": ["2012","2018"],
-      "description": "Reference date (YYYY)"
-    },
-    "delivery_unit": {
-      "type": "string",
-      "pattern": "^DU\\d{4}$",
-      "description": "UTM tile identifier"
-    },
-    "projection": {
-      "type": "string",
-      "enum": "3035",
-      "description": "Spatial projection"
-    },
-    "version": {
-      "type": "string",
-      "pattern": "^V\\d{3}$",
-      "description": "Product version"
-    },
-    "format": {
-      "type": "string",
-      "enum": [
-        "fgdb",
-        "geoPackage"
-      ],
-      "description": "File extension without leading dot"
-    },
-    "extension": {
-      "type": "string",
-      "enum": [
-        "gpkg",
-        "zip"
-      ],
-      "description": "File extension without leading dot"
-    }
+    "prefix": {"type": "string", "enum": ["CZ"], "description": "Constant prefix"},
+    "year": {"type": "string", "enum": ["2012", "2018"], "description": "Reference date (YYYY)"},
+    "delivery_unit": {"type": "string", "pattern": "^DU\\d{4}$", "description": "UTM tile identifier"},
+    "projection": {"type": "string", "enum": ["3035"], "description": "Spatial projection"},
+    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
+    "format": {"type": "string", "enum": ["fgdb", "geoPackage"], "description": "Product format"},
+    "extension": {"type": "string", "enum": ["gpkg", "zip"], "description": "File extension without leading dot"}
   },
   "template": "{prefix}_{year}_{delivery_unit}_{projection}_{version}_{format}[.{extension}]",
   "examples": [

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from parseo import assemble, assemble_auto, clear_schema_cache
+from parseo import assemble, assemble_auto, clear_schema_cache, parse_auto
 
 
 def test_assemble_clms_fsc_schema():
@@ -298,3 +298,21 @@ def test_assemble_auto_n2k_vector_schema():
     result = assemble_auto(fields)
     assert result == "n2k_2018_3035_v1.gpkg"
 
+
+def test_assemble_cgls_ndvi_schema():
+    schema = (
+        Path(__file__).resolve().parents[1]
+        / "src/parseo/schemas/copernicus/clms/cgls/ndvi/ndvi_filename_v0_0_0.json"
+    )
+    fields = {
+        "prefix": "c_gls",
+        "product": "NDVI",
+        "resolution": "300",
+        "sensing_datetime": "202306050000",
+        "region": "GLOBE",
+        "sensor": "PROBAV",
+        "version": "V2.2.1",
+        "extension": "nc",
+    }
+    result = assemble(schema, fields)
+    assert result == "c_gls_NDVI300_202306050000_GLOBE_PROBAV_V2.2.1.nc"

--- a/tests/test_cz_schema.py
+++ b/tests/test_cz_schema.py
@@ -6,34 +6,33 @@ from parseo import assemble, assemble_auto, parse_auto
 def _schema_path() -> Path:
     return Path(__file__).resolve().parents[1] / "src/parseo/schemas/copernicus/cz/cz_filename_v0_0_0.json"
 
-
 def test_assemble_cz_schema():
     schema = _schema_path()
     fields = {
         "prefix": "CZ",
-        "product": "FOO",
-        "tile_id": "T32TNS",
-        "date": "20210101",
-        "version": "V100",
-        "extension": "gpkg",
+        "year": "2012",
+        "delivery_unit": "DU0001",
+        "projection": "3035",
+        "version": "V010",
+        "format": "fgdb",
+        "extension": "zip",
     }
     result = assemble(schema, fields)
-    assert result == "CZ_FOO_T32TNS_20210101_V100.gpkg"
-
+    assert result == "CZ_2012_DU0001_3035_V010_fgdb.zip"
 
 def test_cz_roundtrip_auto():
-    name = "CZ_FOO_T32TNS_20210101_V100.gpkg"
+    name = "CZ_2018_DU0002_3035_V020_fgdb.zip"
     res = parse_auto(name)
-    assert res.fields["product"] == "FOO"
-    assert res.fields["tile_id"] == "T32TNS"
-    assert res.fields["date"] == "20210101"
-    assert res.fields["version"] == "V100"
+    assert res.fields["year"] == "2018"
+    assert res.fields["delivery_unit"] == "DU0002"
+    assert res.fields["projection"] == "3035"
+    assert res.fields["version"] == "V020"
+    assert res.fields["format"] == "fgdb"
     assert assemble_auto(res.fields) == name
 
-
 def test_cz_vector_roundtrip_auto():
-    name = "CZ_BAR_T32TNS_20210202_V101.zip"
+    name = "CZ_2012_DU1234_3035_V100_geoPackage.gpkg"
     res = parse_auto(name)
-    assert res.fields["product"] == "BAR"
-    assert res.fields["extension"] == "zip"
+    assert res.fields["format"] == "geoPackage"
+    assert res.fields["extension"] == "gpkg"
     assert assemble_auto(res.fields) == name

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -157,3 +157,15 @@ def test_clc_example():
     assert res.fields["prefix"] == "CLC"
     assert res.fields["reference_year"] == "2018"
     assert res.fields["product"] == "CLC2018"
+
+def test_cgls_ndvi_example():
+    name = "c_gls_NDVI300_202306050000_GLOBE_PROBAV_V2.2.1.nc"
+    res = parse_auto(name)
+    assert res is not None
+    assert res.fields["prefix"] == "c_gls"
+    assert res.fields["product"] == "NDVI"
+    assert res.fields["resolution"] == "300"
+    assert res.fields["region"] == "GLOBE"
+    assert res.fields["sensor"] == "PROBAV"
+    assert res.fields["version"] == "V2.2.1"
+    assert res.fields["extension"] == "nc"


### PR DESCRIPTION
## Summary
- add schemas for CLMS global NDVI, FAPAR and LAI products
- fix HRLVLCC prefix and update CZ schema
- cover new schemas with tests

## Testing
- `pre-commit run --files tests/test_assembler.py tests/test_parser.py tests/test_cz_schema.py src/parseo/schemas/copernicus/clms/cgls/ndvi/index.json src/parseo/schemas/copernicus/clms/cgls/ndvi/ndvi_filename_v0_0_0.json src/parseo/schemas/copernicus/clms/cgls/fapar/index.json src/parseo/schemas/copernicus/clms/cgls/fapar/fapar_filename_v0_0_0.json src/parseo/schemas/copernicus/clms/cgls/lai/index.json src/parseo/schemas/copernicus/clms/cgls/lai/lai_filename_v0_0_0.json src/parseo/schemas/copernicus/clms/hrlvlcc/hrlvlcc_filename_v0_0_0.json src/parseo/schemas/copernicus/cz/cz_filename_v0_0_0.json` (fails: `command not found`)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68accfa71cd08327ad19c1f630d16729