### PR TITLE
Externalize STAC and catalog configuration

### DIFF
--- a/src/parseo/cli.py
+++ b/src/parseo/cli.py
@@ -7,7 +7,7 @@ import sys
 from typing import Any, Dict, List
 
 from parseo.parser import parse_auto, describe_schema, list_schemas  # parser helpers
-from parseo.stac_dataspace import list_collections_http, sample_collection_filenames
+from parseo.stac_http import list_collections_http, sample_collection_filenames
 
 
 # ---------- small utilities ----------

--- a/src/parseo/clms_catalog.py
+++ b/src/parseo/clms_catalog.py
@@ -17,8 +17,7 @@ from __future__ import annotations
 from html.parser import HTMLParser
 from typing import Iterable, List
 from urllib.request import urlopen
-
-DATASET_CATALOG_URL = "https://land.copernicus.eu/en/dataset-catalog"
+import os
 
 
 class _DatasetTitleParser(HTMLParser):
@@ -61,15 +60,19 @@ def parse_html(html: str) -> List[str]:
     return out
 
 
-def fetch_clms_products(url: str = DATASET_CATALOG_URL) -> List[str]:
+def fetch_clms_products(url: str | None = None) -> List[str]:
     """Fetch the CLMS dataset catalog and return all product titles.
 
-    Parameters
-    ----------
-    url:
-        Optional catalog URL. The default points to the official CLMS
-        dataset catalog.
+    If ``url`` is not provided, the environment variable
+    ``CLMS_DATASET_CATALOG_URL`` is consulted.  A :class:`ValueError` is raised
+    when no URL is available.
     """
+    if url is None:
+        url = os.getenv("CLMS_DATASET_CATALOG_URL")
+        if url is None:
+            raise ValueError(
+                "Catalog URL not provided. Set CLMS_DATASET_CATALOG_URL or pass the 'url' parameter."
+            )
     with urlopen(url) as resp:  # noqa: S310 - controlled URL
         charset = resp.headers.get_content_charset() or "utf-8"
         html = resp.read().decode(charset, "replace")

--- a/src/parseo/stac_scraper.py
+++ b/src/parseo/stac_scraper.py
@@ -1,10 +1,9 @@
 """STAC helpers backed by ``pystac-client``.
 
-This module mirrors the utilities in :mod:`parseo.stac_dataspace` but relies on
+This module mirrors the utilities in :mod:`parseo.stac_http` but relies on
 ``pystac-client`` for STAC catalog traversal.  Use these helpers when the extra
 features of ``pystac-client`` are required.  For a lightweight alternative that
-only depends on the Python standard library see
-:mod:`parseo.stac_dataspace`.
+only depends on the Python standard library see :mod:`parseo.stac_http`.
 """
 from __future__ import annotations
 
@@ -14,7 +13,7 @@ from urllib.parse import urlparse
 def list_collections_client(base_url: str, *, deep: bool = False) -> list[str]:
     """Return collection IDs from a STAC API using ``pystac-client``.
 
-    Parameters mirror :func:`parseo.stac_dataspace.list_collections_http` but
+    Parameters mirror :func:`parseo.stac_http.list_collections_http` but
     this variant requires the optional ``pystac-client`` dependency.  It is
     suitable when more advanced STAC handling is needed, at the cost of pulling
     in the external library.
@@ -52,7 +51,7 @@ def list_collections_client(base_url: str, *, deep: bool = False) -> list[str]:
     return sorted(collections)
 
 
-# Backwards compatible alias mirroring :mod:`parseo.stac_dataspace`
+# Backwards compatible alias mirroring :mod:`parseo.stac_http`
 list_collections = list_collections_client
 
 


### PR DESCRIPTION
## Summary
- remove hard-coded CDSE STAC aliases and resolve collection IDs by listing available collections from the STAC API
- make CLMS catalog URL configurable via `CLMS_DATASET_CATALOG_URL` env var or argument
- rename dataspace-specific STAC helpers to generic `stac_http`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adf39378e48327a079f085ea694f56