### PR TITLE
feat: add STAC metadata to EUMETSAT schemas

### DIFF
--- a/src/parseo/schemas/eumetsat/metop/metop_filename_v1_0_0.json
+++ b/src/parseo/schemas/eumetsat/metop/metop_filename_v1_0_0.json
@@ -1,6 +1,13 @@
 {
   "schema_id": "eumetsat:metop",
   "schema_version": "1.0.0",
+  "stac_version": "1.1.0",
+  "stac_extensions": [
+    "processing",
+    "sat",
+    "raster",
+    "eo"
+  ],
   "fields": {
     "platform": {
       "type": "string",

--- a/src/parseo/schemas/eumetsat/mtg/mtg_filename_v1_0_0.json
+++ b/src/parseo/schemas/eumetsat/mtg/mtg_filename_v1_0_0.json
@@ -1,6 +1,13 @@
 {
   "schema_id": "eumetsat:mtg",
   "schema_version": "1.0.0",
+  "stac_version": "1.1.0",
+  "stac_extensions": [
+    "processing",
+    "sat",
+    "raster",
+    "eo"
+  ],
   "fields": {
     "platform": {
       "type": "string",


### PR DESCRIPTION
## Summary
- annotate Metop filename schema with STAC version and extensions
- annotate MTG filename schema with STAC version and extensions

## Testing
- `pytest`
- `pre-commit run --files src/parseo/schemas/eumetsat/metop/metop_filename_v1_0_0.json src/parseo/schemas/eumetsat/mtg/mtg_filename_v1_0_0.json` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae11b5027c8327ae53ac030782424b