### PR TITLE
Add descriptions and STAC mapping for Sentinel-3 filename schema

### DIFF
--- a/src/parseo/schemas/copernicus/sentinel/s3/s3_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s3/s3_filename_v1_0_0.json
@@ -5,12 +5,12 @@
   "stac_extensions": ["processing", "sat", "raster", "eo"],
   "description": "Sentinel-3 product filename (OLCI/SLSTR/SRAL; optional relative orbit, segment, extension).",
   "fields": {
-    "platform": {"type": "string", "enum": ["S3A", "S3B", "S3C"]},
-    "instrument": {"type": "string", "enum": ["OLCI", "SLSTR", "SRAL"]},
-    "processing_level": {"type": "string", "enum": ["L0", "L1", "L2"]},
-    "sensing_datetime": {"type": "string", "pattern": "^\\d{8}T\\d{6}$"},
-    "relative_orbit": {"type": "string", "pattern": "^\\d{3}$"},
-    "segment": {"type": "string", "pattern": "^[A-Z0-9_\\-]{1,10}$"},
+    "platform": {"type": "string", "enum": ["S3A", "S3B", "S3C"], "description": "Spacecraft unit (platform)"},
+    "instrument": {"type": "string", "enum": ["OLCI", "SLSTR", "SRAL"], "description": "Instrument (instruments)"},
+    "processing_level": {"type": "string", "enum": ["L0", "L1", "L2"], "description": "Processing level (processing:level)"},
+    "sensing_datetime": {"type": "string", "pattern": "^\\d{8}T\\d{6}$", "description": "Acquisition datetime (datetime)"},
+    "relative_orbit": {"type": "string", "pattern": "^\\d{3}$", "description": "Relative orbit number (sat:relative_orbit)"},
+    "segment": {"type": "string", "pattern": "^[A-Z0-9_\\-]{1,10}$", "description": "Segment identifier"},
     "extension": {"type": "string", "pattern": "^[A-Za-z0-9]+$", "description": "File extension without leading dot"}
   },
   "template": "{platform}_{instrument}_{processing_level}_{sensing_datetime}[_{relative_orbit}][_{segment}][.{extension}]",


### PR DESCRIPTION
## Summary
- describe Sentinel-3 filename fields
- note STAC property mappings

## Testing
- `pytest`
- `pre-commit run --files src/parseo/schemas/copernicus/sentinel/s3/s3_filename_v1_0_0.json` *(fails: command not found; package install blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68ae11b99b74832799011a7a49c77ea7