### PR TITLE
chore: omit required from template schema

### DIFF
--- a/examples/schema_skeleton/template_filename_v0_0_1.json
+++ b/examples/schema_skeleton/template_filename_v0_0_1.json
@@ -32,7 +32,6 @@
       "description": "File extension without leading dot"
     }
   },
-  "required": ["prefix", "product", "sensing_datetime", "version"],
   "template": "{prefix}_{product}_{sensing_datetime}_{version}[.{extension}]",
   "examples": [
     "PRD_XYZ_20240101T000000_V100.tif"


### PR DESCRIPTION
## Summary
- remove `required` section from schema skeleton example

## Testing
- `pytest`
- `pre-commit run --files examples/schema_skeleton/template_filename_v0_0_1.json` *(fails: command not found; pip install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68aed33238048327b2f592ac3e24f7a1