### PR TITLE
Discover schema families from schema files

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,18 +347,17 @@ parseo assemble \
 
 Adding support for a new product requires only a JSON schema placed under
 `src/parseo/schemas/`. All field definitions live inside the schema file.
-For a starting point, see the skeleton schema and index under
+For a starting point, see the skeleton schema under
 `examples/schema_skeleton/`.
 
 1. **Create the product directory**
    - Path: `src/parseo/schemas/<family>/<mission>/<product>/`
-   - Add an `index.json` pointing to the active schema file. The `version`
-     key in `index.json` is optional; `status` and `file` are required.
 
 2. **Write the versioned schema file**
    - Filename: `<product>_filename_vX_Y_Z.json`
    - Include top-level metadata such as `schema_id`, `schema_version`,
-     `stac_version`, optional `stac_extensions`, and a short `description`.
+     `status` (`current`, `deprecated`, etc.), `stac_version`, optional
+     `stac_extensions`, and a short `description`.
 
 3. **Define fields inline**
    - Add a top-level `"fields"` object. Each field uses JSON Schema
@@ -382,7 +381,7 @@ For a starting point, see the skeleton schema and index under
 
 6. **Maintain versions**
    - When the schema evolves, create a new file with an incremented version
-     and update `index.json` to mark it as `current`.
+     and mark the latest one with `"status": "current"`.
 
 7. **Test the schema**
    - Use `parseo parse <filename>` to check parsing and `parseo assemble`

--- a/src/parseo/schemas/copernicus/clms/clc/clc_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/clc/clc_filename_v1_0_0.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_id": "copernicus:clms:clc",
   "schema_version": "1.0.0",
+  "status": "current",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
   "description": "Corine Land Cover product filename (extension optional).",

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/st/st_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/st/st_filename_v0_0_0.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_id": "copernicus:clms:hr-vpp:st",
   "schema_version": "0.0.0",
+  "status": "current",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
   "description": "CLMS HR-VPP Seasonal Trajectories Plant Phenology Index product filename (extension optional).",

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/vegetation_index_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/vegetation_index_filename_v0_0_0.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_id": "copernicus:clms:hr-vpp:vegetation-index",
   "schema_version": "0.0.0",
+  "status": "current",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
   "description": "CLMS HR-VPP Vegetation Indices (FAPAR, LAI, NDVI, PPI, FCOVER, DMP) product filename (extension optional).",

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/cc/cc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/cc/cc_filename_v0_0_0.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_id": "copernicus:clms:hr-wsi:cc",
   "schema_version": "0.0.0",
+  "status": "current",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
   "description": "CLMS HR-WSI Cloud Cover product filename (extension optional).",

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/fsc/fsc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/fsc/fsc_filename_v0_0_0.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_id": "copernicus:clms:hr-wsi:fsc",
   "schema_version": "0.0.0",
+  "status": "current",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
   "description": "CLMS HR-WSI Fractional Snow Cover product filename (extension optional).",

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/gfsc/gfsc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/gfsc/gfsc_filename_v0_0_0.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_id": "copernicus:clms:hr-wsi:gfsc",
   "schema_version": "0.0.0",
+  "status": "current",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
   "description": "CLMS HR-WSI Gap-filled Fractional Snow Cover product filename (extension optional).",

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/icd/icd_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/icd/icd_filename_v0_0_0.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_id": "copernicus:clms:hr-wsi:icd",
   "schema_version": "0.0.0",
+  "status": "current",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
   "description": "CLMS HR-WSI Ice Cover Duration product filename (extension optional).",

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/sp_comb/sp_comb_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/sp_comb/sp_comb_filename_v0_0_0.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_id": "copernicus:clms:hr-wsi:sp-comb",
   "schema_version": "0.0.0",
+  "status": "current",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
   "description": "CLMS HR-WSI Snow Products combination filename (extension optional).",

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/sp_s2/sp_s2_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/sp_s2/sp_s2_filename_v0_0_0.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_id": "copernicus:clms:hr-wsi:sp-s2",
   "schema_version": "0.0.0",
+  "status": "current",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
   "description": "CLMS HR-WSI Snow Products Sentinel-2 source filename (extension optional).",

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/sws/sws_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/sws/sws_filename_v0_0_0.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_id": "copernicus:clms:hr-wsi:sws",
   "schema_version": "0.0.0",
+  "status": "current",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
   "description": "CLMS HR-WSI Small Water Surface product filename (extension optional).",

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/wds/wds_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/wds/wds_filename_v0_0_0.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_id": "copernicus:clms:hr-wsi:wds",
   "schema_version": "0.0.0",
+  "status": "current",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
   "description": "CLMS HR-WSI Water Detection and Surface Displacement product filename (extension optional).",

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/wic_comb/wic_comb_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/wic_comb/wic_comb_filename_v0_0_0.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_id": "copernicus:clms:hr-wsi:wic-comb",
   "schema_version": "0.0.0",
+  "status": "current",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
   "description": "CLMS HR-WSI Water and Ice Cover combination filename (extension optional).",

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/wic_s1/wic_s1_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/wic_s1/wic_s1_filename_v0_0_0.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_id": "copernicus:clms:hr-wsi:wic-s1",
   "schema_version": "0.0.0",
+  "status": "current",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
   "description": "CLMS HR-WSI Water and Ice Cover Sentinel-1 product filename (extension optional).",

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/wic_s2/wic_s2_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/wic_s2/wic_s2_filename_v0_0_0.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_id": "copernicus:clms:hr-wsi:wic-s2",
   "schema_version": "0.0.0",
+  "status": "current",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
   "description": "CLMS HR-WSI Water and Ice Cover Sentinel-2 product filename (extension optional).",

--- a/src/parseo/schemas/copernicus/clms/hrl/forest-type/forest-type_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/forest-type/forest-type_filename_v0_0_0.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_id": "copernicus:clms:hrl:forest-type",
   "schema_version": "0.0.0",
+  "status": "current",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
   "description": "CLMS High Resolution Layer Forest Type product filename (extension optional).",

--- a/src/parseo/schemas/copernicus/clms/hrl/grassland/grassland_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/grassland/grassland_filename_v0_0_0.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_id": "copernicus:clms:hrl:grassland",
   "schema_version": "0.0.0",
+  "status": "current",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
   "description": "CLMS High Resolution Layer Grassland product filename (extension optional).",

--- a/src/parseo/schemas/copernicus/clms/hrl/imperviousness/imperviousness_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/imperviousness/imperviousness_filename_v0_0_0.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_id": "copernicus:clms:hrl:imperviousness",
   "schema_version": "0.0.0",
+  "status": "current",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
   "description": "CLMS High Resolution Layer Imperviousness product filename (extension optional).",

--- a/src/parseo/schemas/copernicus/clms/hrl/small-woody-features/small-woody-features_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/small-woody-features/small-woody-features_filename_v0_0_0.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_id": "copernicus:clms:hrl:small-woody-features",
   "schema_version": "0.0.0",
+  "status": "current",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
   "description": "CLMS High Resolution Layer Small Woody Features product filename (extension optional).",

--- a/src/parseo/schemas/copernicus/clms/hrl/tree-cover-density/tree-cover-density_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/tree-cover-density/tree-cover-density_filename_v0_0_0.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_id": "copernicus:clms:hrl:tree-cover-density",
   "schema_version": "0.0.0",
+  "status": "current",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
   "description": "CLMS High Resolution Layer Tree Cover Density product filename (extension optional).",

--- a/src/parseo/schemas/copernicus/clms/hrl/water-wetness/water-wetness_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/water-wetness/water-wetness_filename_v0_0_0.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_id": "copernicus:clms:hrl:water-wetness",
   "schema_version": "0.0.0",
+  "status": "current",
   "stac_version": "1.1.0",
   "stac_extensions": ["raster", "eo"],
   "description": "CLMS High Resolution Layer Water & Wetness product filename (extension optional).",

--- a/src/parseo/schemas/copernicus/sentinel/s1/s1_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s1/s1_filename_v1_0_0.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_id": "copernicus:sentinel:s1",
   "schema_version": "1.0.0",
+  "status": "current",
   "stac_version": "1.1.0",
   "stac_extensions": ["processing", "sat", "sar"],
   "description": "Sentinel-1 product filename; TTTR token is RAW_, SLC_, OCN_, or GRD(F|H|M|E); extension optional.",

--- a/src/parseo/schemas/copernicus/sentinel/s2/s2_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s2/s2_filename_v1_0_0.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_id": "copernicus:sentinel:s2",
   "schema_version": "1.0.0",
+  "status": "current",
   "stac_version": "1.1.0",
   "stac_extensions": ["processing", "sat", "raster", "eo", "mgrs"],
   "description": "Sentinel-2 product filename (MSI sensor, processing levels L1C/L2A; extension optional).",

--- a/src/parseo/schemas/copernicus/sentinel/s3/s3_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s3/s3_filename_v1_0_0.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_id": "copernicus:sentinel:s3",
   "schema_version": "1.0.0",
+  "status": "current",
   "stac_version": "1.1.0",
   "stac_extensions": ["processing", "sat", "raster", "eo"],
   "description": "Sentinel-3 product filename (OLCI/SLSTR/SRAL; optional relative orbit, segment, extension).",

--- a/src/parseo/schemas/copernicus/sentinel/s4/s4_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s4/s4_filename_v1_0_0.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_id": "copernicus:sentinel:s4",
   "schema_version": "1.0.0",
+  "status": "current",
   "stac_version": "1.1.0",
   "stac_extensions": ["processing", "sat", "raster", "eo"],
   "description": "Sentinel-4 product filename (UVN; optional tile, extension).",

--- a/src/parseo/schemas/copernicus/sentinel/s5p/s5p_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s5p/s5p_filename_v1_0_0.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_id": "copernicus:sentinel:s5p",
   "schema_version": "1.0.0",
+  "status": "current",
   "stac_version": "1.1.0",
   "stac_extensions": ["processing", "sat", "raster", "eo"],
   "description": "Sentinel-5P product filename (TROPOMI; extension optional).",

--- a/src/parseo/schemas/copernicus/sentinel/s6/s6_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s6/s6_filename_v1_0_0.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_id": "copernicus:sentinel:s6",
   "schema_version": "1.0.0",
+  "status": "current",
   "stac_version": "1.1.0",
   "stac_extensions": ["processing", "sat"],
   "description": "Sentinel-6 product filename (P4 altimetry; extension optional).",

--- a/src/parseo/schemas/eumetsat/metop/metop_filename_v1_0_0.json
+++ b/src/parseo/schemas/eumetsat/metop/metop_filename_v1_0_0.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_id": "eumetsat:metop",
   "schema_version": "1.0.0",
+  "status": "current",
   "description": "EUMETSAT Metop product filename (extension optional).",
   "stac_version": "1.1.0",
   "stac_extensions": [

--- a/src/parseo/schemas/eumetsat/mtg/mtg_filename_v1_0_0.json
+++ b/src/parseo/schemas/eumetsat/mtg/mtg_filename_v1_0_0.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_id": "eumetsat:mtg",
   "schema_version": "1.0.0",
+  "status": "current",
   "description": "EUMETSAT MTG product filename (extension optional).",
   "stac_version": "1.1.0",
   "stac_extensions": [

--- a/src/parseo/schemas/nasa/modis/modis_filename_v1_0_0.json
+++ b/src/parseo/schemas/nasa/modis/modis_filename_v1_0_0.json
@@ -2,6 +2,7 @@
   "schema_id": "nasa:modis",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_version": "1.0.0",
+  "status": "current",
   "stac_version": "1.1.0",
   "description": "MODIS product filename (extension optional).",
   "fields": {

--- a/src/parseo/schemas/usgs/landsat/landsat_filename_v1_0_0.json
+++ b/src/parseo/schemas/usgs/landsat/landsat_filename_v1_0_0.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_id": "usgs:landsat:landsat",
   "schema_version": "1.0.0",
+  "status": "current",
   "stac_version": "1.1.0",
   "stac_extensions": ["processing", "sat", "eo"],
   "description": "Landsat Collection 2 scene identifier (extension optional).",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -18,7 +18,7 @@ def test_schema_paths_cached(monkeypatch):
     monkeypatch.setattr(parser, "_discover_family_info", wrapped)
     parser._discover_family_info.cache_clear()
 
-    # Two parses should trigger only a single scan of index.json files
+    # Two parses should trigger only a single discovery of schema files
     parser.parse_auto("S2B_MSIL2A_20241123T224759_N0511_R101_T03VUL_20241123T230829.SAFE")
     parser.parse_auto("S1A_IW_SLC__1SDV_20250105T053021_20250105T053048_A054321_D068F2E_ABC123.SAFE")
 


### PR DESCRIPTION
## Summary
- add `status` metadata to all schema JSON files
- discover families and versions by scanning schema files
- document new schema process and drop `index.json`

## Testing
- `pytest`
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68aed9e90d70832799fee03383dd0b7e