### PR TITLE
fix: remove obsolete validator import

### DIFF
--- a/src/parseo/__init__.py
+++ b/src/parseo/__init__.py
@@ -1,6 +1,5 @@
 from .parser import parse_auto, validate_schema_examples
 from .assembler import assemble, assemble_auto, clear_schema_cache
-from .validator import validate_schema_examples
 from .schema_registry import (
     list_schema_families,
     list_schema_versions,


### PR DESCRIPTION
## Summary
- remove stale validator import in package initializer

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af1facb9cc832789d23533e096089d