### PR TITLE
Simplify STAC mapping declarations for MODIS schema

### DIFF
--- a/examples/schema_skeleton/template_filename_v0_0_1.json
+++ b/examples/schema_skeleton/template_filename_v0_0_1.json
@@ -10,7 +10,13 @@
     "prefix": {
       "type": "string",
       "pattern": "^PRD$",
-      "description": "Static prefix identifying the product family"
+      "description": "Static prefix identifying the product family",
+      "stac_map": {
+        "PRD": {
+          "platform": "ExamplePlatform",
+          "instrument": "ExampleInstrument"
+        }
+      }
     },
     "product": {
       "type": "string",

--- a/src/parseo/_field_mappings.py
+++ b/src/parseo/_field_mappings.py
@@ -1,0 +1,125 @@
+"""Utilities for translating between schema tokens and STAC values."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from typing import Dict
+from typing import Mapping
+
+
+@dataclass(frozen=True)
+class FieldMapping:
+    """Represents a mapping between a filename token and STAC fields."""
+
+    preserve_as: str
+    token_map: Dict[str, Dict[str, Any]]
+
+
+def _normalize_mapping_values(values: Mapping[str, Any]) -> Dict[str, Dict[str, Any]]:
+    normalized: Dict[str, Dict[str, Any]] = {}
+    for token, targets in values.items():
+        if not isinstance(targets, Mapping):
+            continue
+        normalized[str(token)] = {str(k): v for k, v in targets.items()}
+    return normalized
+
+
+def get_schema_field_mappings(schema: Mapping[str, Any]) -> Dict[str, FieldMapping]:
+    """Extract field mappings declared in *schema*."""
+
+    fields = schema.get("fields", {})
+    if not isinstance(fields, Mapping):
+        return {}
+
+    mappings: Dict[str, FieldMapping] = {}
+    for field_name, spec in fields.items():
+        if not isinstance(spec, Mapping):
+            continue
+        raw_map = spec.get("stac_map")
+        if not isinstance(raw_map, Mapping):
+            continue
+
+        preserve_as = raw_map.get("preserve_original_as")
+        values: Any
+        if "values" in raw_map:
+            values = raw_map.get("values")
+        else:
+            values = raw_map
+        if not isinstance(values, Mapping):
+            continue
+
+        normalized = _normalize_mapping_values(values)
+        if not normalized:
+            continue
+
+        if not isinstance(preserve_as, str) or not preserve_as:
+            preserve_as = f"{field_name}_code"
+
+        mappings[str(field_name)] = FieldMapping(preserve_as=preserve_as, token_map=normalized)
+
+    return mappings
+
+
+def apply_schema_mappings(
+    extracted: Dict[str, Any], schema: Mapping[str, Any]
+) -> Dict[str, Any]:
+    """Augment *extracted* fields with STAC values defined in *schema*."""
+
+    mappings = get_schema_field_mappings(schema)
+    if not mappings:
+        return extracted
+
+    enriched = dict(extracted)
+    for field_name, mapping in mappings.items():
+        token = extracted.get(field_name)
+        if token is None:
+            continue
+
+        enriched[mapping.preserve_as] = token
+
+        targets = mapping.token_map.get(str(token))
+        if not isinstance(targets, Mapping):
+            continue
+
+        for target_field, target_value in targets.items():
+            enriched[target_field] = target_value
+
+    return enriched
+
+
+def translate_fields_to_tokens(
+    fields: Dict[str, Any], schema: Mapping[str, Any]
+) -> Dict[str, Any]:
+    """Translate STAC field values in *fields* back to schema tokens."""
+
+    mappings = get_schema_field_mappings(schema)
+    if not mappings:
+        return fields
+
+    translated = dict(fields)
+    for field_name, mapping in mappings.items():
+        token: Any = None
+
+        preserved = fields.get(mapping.preserve_as)
+        if preserved not in (None, ""):
+            token = str(preserved)
+
+        if token is None:
+            current_value = fields.get(field_name)
+            if isinstance(current_value, str) and current_value in mapping.token_map:
+                token = current_value
+
+        if token is None:
+            for candidate, targets in mapping.token_map.items():
+                if all(fields.get(k) == v for k, v in targets.items()):
+                    token = candidate
+                    break
+
+        if token is None:
+            continue
+
+        translated[field_name] = token
+
+    return translated
+

--- a/src/parseo/assembler.py
+++ b/src/parseo/assembler.py
@@ -10,6 +10,7 @@ from typing import Any
 from typing import Dict
 from typing import Union
 
+from ._field_mappings import translate_fields_to_tokens
 from ._json import load_json
 from .schema_registry import get_schema_path
 from .template import _field_regex
@@ -80,10 +81,11 @@ def _assemble_schema(schema_path: Union[str, Path], fields: Dict[str, Any]) -> s
     """
 
     sch = _load_schema(schema_path)
+    prepared_fields = translate_fields_to_tokens(fields, sch)
 
     # Validate provided fields against schema definitions
     specs = sch.get("fields", {})
-    for name, value in fields.items():
+    for name, value in prepared_fields.items():
         spec = specs.get(name)
         if not spec:
             continue
@@ -104,7 +106,7 @@ def _assemble_schema(schema_path: Union[str, Path], fields: Dict[str, Any]) -> s
         raise ValueError(f"Schema {schema_path} missing 'template' string.")
 
     try:
-        return _assemble_from_template(template, fields)
+        return _assemble_from_template(template, prepared_fields)
     except KeyError as exc:
         name = exc.args[0]
         raise ValueError(

--- a/src/parseo/parser.py
+++ b/src/parseo/parser.py
@@ -13,6 +13,7 @@ from typing import Iterable
 from typing import Optional
 from typing import Union
 
+from ._field_mappings import apply_schema_mappings
 from .schema_registry import _discover_family_info
 from .schema_registry import _get_schema_paths
 from .schema_registry import _load_json_from_path
@@ -96,7 +97,10 @@ def _extract_fields(name: str, schema: Dict) -> Dict[str, str]:
     If the regex doesn't match, return an empty dict.
     """
     m = _match_filename(name, schema)
-    return m.groupdict() if m else {}
+    if not m:
+        return {}
+    extracted = m.groupdict()
+    return apply_schema_mappings(extracted, schema)
 
 
 def _try_validate(name: str, schema: Dict) -> bool:

--- a/src/parseo/schemas/nasa/modis/modis_filename_v1_0_0.json
+++ b/src/parseo/schemas/nasa/modis/modis_filename_v1_0_0.json
@@ -9,7 +9,21 @@
     "platform": {
       "type": "string",
       "pattern": "^(MOD|MYD|MCD)$",
-      "description": "Spacecraft platform (MOD=Terra, MYD=Aqua, MCD=Combined)"
+      "description": "Spacecraft platform (MOD=Terra, MYD=Aqua, MCD=Combined)",
+      "stac_map": {
+        "MOD": {
+          "platform": "Terra",
+          "instrument": "MODIS"
+        },
+        "MYD": {
+          "platform": "Aqua",
+          "instrument": "MODIS"
+        },
+        "MCD": {
+          "platform": "Combined",
+          "instrument": "MODIS"
+        }
+      }
     },
     "product": {
       "type": "string",

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -87,3 +87,24 @@ def test_assemble_with_family_s2():
         == "S2B_MSIL2A_20241123T224759_N0511_R101_T03VUL_20241123T230829.SAFE"
     )
 
+
+def test_assemble_modis_from_stac_fields():
+    schema = (
+        Path(__file__).resolve().parents[1]
+        / "src/parseo/schemas/nasa/modis/modis_filename_v1_0_0.json"
+    )
+    fields = {
+        "platform": "Terra",
+        "instrument": "MODIS",
+        "product": "09",
+        "variant": "GA",
+        "acq_date": "A2021123",
+        "tile": "h18v04",
+        "collection": "006",
+        "proc_date": "2021132234506",
+        "extension": "hdf",
+    }
+
+    assembled = assemble(fields, schema_path=schema)
+    assert assembled == "MOD09GA.A2021123.h18v04.006.2021132234506.hdf"
+

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -179,3 +179,15 @@ def test_parse_urban_atlas_lcu():
         "production_date": "20240212",
         "extension": None,
     }
+
+
+def test_parse_modis_stac_mapping():
+    name = "MOD09GA.A2021123.h18v04.006.2021132234506.hdf"
+    result = parse_auto(name)
+
+    assert result.valid
+    assert result.match_family == "MODIS"
+    assert result.fields["platform"] == "Terra"
+    assert result.fields["instrument"] == "MODIS"
+    assert result.fields["platform_code"] == "MOD"
+    assert result.fields["product"] == "09"


### PR DESCRIPTION
## Summary
- add reusable utilities for translating schema token mappings to STAC fields
- expose MODIS platform prefix mappings so parsed results include STAC platform/instrument data alongside the original code
- update parser/assembler workflows and tests to cover the new mapping behaviour
- document the simplified flat mapping pattern in the schema skeleton and adopt it in the MODIS schema

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfc9a327108327a25a52d66662da93