### PR TITLE
Add schema for CLMS impervious built-up area filenames

### DIFF
--- a/src/parseo/schemas/copernicus/clms/hrl/impervious-built-up-area/impervious-built-up-area_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/impervious-built-up-area/impervious-built-up-area_filename_v0_0_0.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema_id": "copernicus:clms:hrl:impervious-built-up-area",
+  "schema_version": "0.0.0",
+  "status": "current",
+  "stac_version": "1.1.0",
+  "stac_extensions": ["raster", "eo"],
+  "description": "CLMS High Resolution Layer Impervious Built-up Area product filename (extension optional).",
+  "fields": {
+    "product": {"type": "string", "enum": ["IBU"], "description": "Product code"},
+    "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
+    "resolution": {"type": "string", "pattern": "^\\d{3}m$", "description": "Spatial resolution in metres with leading zeros"},
+    "tile": {"type": "string", "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$", "description": "EEA reference grid tile identifier"},
+    "epsg_code": {"type": "string", "pattern": "^\\d{5}$", "description": "EPSG code padded to five digits"},
+    "version": {"type": "string", "pattern": "^v\\d{3}$", "description": "Product version"},
+    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+  },
+  "template": "{product}_{reference_year}_{resolution}_{tile}_{epsg_code}_{version}[.{extension}]",
+  "examples": [
+    "IBU_2018_010m_E47N18_03035_v010.tif",
+    "IBU_2018_010m_E47N19_03035_v010.tif",
+    "IBU_2018_010m_E48N18_03035_v010.tif",
+    "IBU_2018_010m_E49N19_03035_v010.tif",
+    "IBU_2018_010m_E50N19_03035_v010.tif"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a schema describing CLMS HRL Impervious Built-up Area filenames including field constraints and representative examples

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dff43e5e10832786af764f95f58909