### PR TITLE
Standardize LAEA tile tokens

### DIFF
--- a/src/parseo/schemas/copernicus/clms/hrl/impervious-built-up-area_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/impervious-built-up-area_filename_v0_0_0.json
@@ -10,7 +10,11 @@
     "product": {"type": "string", "enum": ["IBU"], "description": "Product code"},
     "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
     "resolution": {"type": "string", "pattern": "^\\d{3}m$", "description": "Spatial resolution in metres with leading zeros"},
-    "tile": {"type": "string", "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$", "description": "EEA reference grid tile identifier"},
+    "tile": {
+      "type": "string",
+      "pattern": "^[EW]\\d{2}[NS]\\d{2}$",
+      "description": "Tile identifier in the EEA 10m grid (easting/northing)"
+    },
     "epsg_code": {"type": "string", "pattern": "^\\d{4,5}$", "description": "EPSG code (optionally zero-padded to five digits)"},
     "version": {"type": "string", "pattern": "^v\\d{3}$", "description": "Product version"},
     "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}

--- a/src/parseo/schemas/copernicus/clms/hrl/non-vegetated-land-cover-characteristics_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/non-vegetated-land-cover-characteristics_filename_v0_0_0.json
@@ -34,8 +34,8 @@
     },
     "tile": {
       "type": "string",
-      "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
-      "description": "EEA reference grid tile identifier"
+      "pattern": "^[EW]\\d{2}[NS]\\d{2}$",
+      "description": "Tile identifier in the EEA 10m grid (easting/northing)"
     },
     "epsg_code": {
       "type": "string",

--- a/src/parseo/schemas/copernicus/clms/hrl/vegetated-land-cover-characteristics_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/vegetated-land-cover-characteristics_filename_v0_0_0.json
@@ -34,8 +34,8 @@
     },
     "tile": {
       "type": "string",
-      "pattern": "^(?:[EW]\\d{2,3}[NS]\\d{2,3}|[A-Z]{2})$",
-      "description": "EEA reference grid tile identifier or two-letter geographic code"
+      "pattern": "^(?:[EW]\\d{2}[NS]\\d{2}|[A-Z]{2})$",
+      "description": "Tile identifier in the EEA 10m grid (easting/northing) or two-letter geographic code"
     },
     "epsg_code": {
       "type": "string",

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -13,7 +13,7 @@ from parseo import (
 def test_assemble_missing_field_template_schema():
     schema = (
         Path(__file__).resolve().parents[1]
-        / "src/parseo/schemas/copernicus/clms/hr-wsi/fsc/fsc_filename_v0_0_0.json"
+        / "src/parseo/schemas/copernicus/clms/hr-wsi/fsc_filename_v0_0_0.json"
     )
     fields = {
         "prefix": "CLMS_WSI",
@@ -91,7 +91,7 @@ def test_assemble_with_family_s2():
 def test_assemble_modis_from_stac_fields():
     schema = (
         Path(__file__).resolve().parents[1]
-        / "src/parseo/schemas/nasa/modis/modis_filename_v1_0_0.json"
+        / "src/parseo/schemas/nasa/modis_filename_v1_0_0.json"
     )
     fields = {
         "platform": "Terra",


### PR DESCRIPTION
## Summary
- tighten LAEA tile validation to the two-digit EEA 10m grid token across HRL schemas
- align test assembler schema paths with on-disk layout to keep unit coverage intact

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e10fd244a8832789459c18f0806e05