### PR TITLE
Add vector type discriminator to UA DHM schema

### DIFF
--- a/src/parseo/schemas/copernicus/clms/urban-atlas/ua_dhm_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/urban-atlas/ua_dhm_filename_v0_0_0.json
@@ -18,13 +18,18 @@
       "description": "City or metropolitan area identifier (letters, digits and hyphen)"
     },
     "product": {
-      "type": "string", 
-      "enum": ["UA"], 
+      "type": "string",
+      "enum": ["UA"],
       "description": "Product code"
     },
+    "type": {
+      "type": "string",
+      "enum": ["V"],
+      "description": "Data type vector"
+    },
     "reference_year": {
-      "type": "string", 
-      "pattern": "^\\d{4}$", 
+      "type": "string",
+      "pattern": "^\\d{4}$",
       "description": "Reference year"
     },
     "variable": {


### PR DESCRIPTION
## Summary
- add an explicit `type` field to the Urban Atlas DHM schema to capture its vector data classification

## Testing
- ruff check .
- pytest *(fails: ValueError: substring not found in template parsing; existing issue)*

------
https://chatgpt.com/codex/tasks/task_e_68e140b808f48327a19bd06d38090bf0