### PR TITLE
Restore legacy CLC schema and improve hinted parsing fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,8 @@ parseo parse S1A_IW_SLC__1SDV_20250105T053021_20250105T053048_A054321_D068F2E_AB
 parseo list-schemas
 FAMILY               VERSION STATUS  FILE
 CC                   0.0.0   current ...\src\parseo\schemas\copernicus\clms\hr-wsi\cc\cc_filename_v0_0_0.json
-CLC                  1.0.0   current ...\src\parseo\schemas\copernicus\clms\clc\clc_filename_v1_0_0.json
+CLC                  1.1.0   current ...\src\parseo\schemas\copernicus\clms\clc\clc_filename_v1_1_0.json
+CLC                  1.0.0   deprecated ...\src\parseo\schemas\copernicus\clms\clc\clc_filename_v1_0_0.json
 FOREST-TYPE          0.0.0   current ...\src\parseo\schemas\copernicus\clms\hrl\forest-type\forest-type_filename_v0_0_0.json
 FSC                  0.0.0   current ...\src\parseo\schemas\copernicus\clms\hr-wsi\fsc\fsc_filename_v0_0_0.json
 GFSC                 0.0.0   current ...\src\parseo\schemas\copernicus\clms\hr-wsi\gfsc\gfsc_filename_v0_0_0.json

--- a/src/parseo/schemas/copernicus/clms/clc/clc_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/clc/clc_filename_v1_0_0.json
@@ -2,9 +2,12 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "schema_id": "copernicus:clms:clc",
   "schema_version": "1.0.0",
-  "status": "current",
+  "status": "deprecated",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "Corine Land Cover product filename (extension optional).",
   "fields": {
     "project": {

--- a/src/parseo/schemas/copernicus/clms/clc/clc_filename_v1_1_0.json
+++ b/src/parseo/schemas/copernicus/clms/clc/clc_filename_v1_1_0.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema_id": "copernicus:clms:clc",
+  "schema_version": "1.1.0",
+  "status": "current",
+  "stac_version": "1.1.0",
+  "stac_extensions": [],
+  "description": "Corine Land Cover filename (status and change layers, extension optional).",
+  "fields": {
+    "update_campaign": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "Year of the CLC update campaign (YYYY)."
+    },
+    "theme": {
+      "type": "string",
+      "enum": ["CLC", "CHA"],
+      "description": "Layer theme: CLC for status layers, CHA for change layers."
+    },
+    "reference_code": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "Reference year (status) or two-year span code (change)."
+    },
+    "change_component": {
+      "type": "string",
+      "pattern": "^(?:12|18)$",
+      "description": "Change raster component: 12 for consumption, 18 for formation."
+    },
+    "release_year": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "Year of data release (YYYY)."
+    },
+    "release_number": {
+      "type": "string",
+      "pattern": "^\\d{2}(?:[A-Za-z]\\d+)?$",
+      "description": "Release identifier (e.g., 20, 20b2, 20u1)."
+    },
+    "country_code": {
+      "type": "string",
+      "pattern": "^[A-Z]{2}$",
+      "description": "ISO 3166-1 alpha-2 country code for overseas deliveries."
+    },
+    "dom_code": {
+      "type": "string",
+      "pattern": "^[A-Z]{3}$",
+      "description": "DOM (overseas department) code used with country_code."
+    },
+    "extension": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9]+$",
+      "description": "File extension without leading dot."
+    }
+  },
+  "template": "U{update_campaign}_{theme}{reference_code}[_{change_component}]_V{release_year}_{release_number}[_{country_code}_{dom_code}][.{extension}]",
+  "examples": [
+    "U2006_CLC2000_V2018_20b2.zip",
+    "U2018_CHA1218_V2020_20u1.tif",
+    "U2018_CHA1218_12_V2020_20u1.tif",
+    "U2006_CLC2000_V2018_20b2_FR_GLP.zip"
+  ]
+}


### PR DESCRIPTION
## Summary
- restore the CLC v1.0.0 filename schema as deprecated so legacy products remain parseable and listed
- relax hinted parsing in `parse_auto` to fall back to other schema versions when the current one mismatches

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1654af87c8327a662fc620b2a6519