### PR TITLE
Add schema for CLMS N2K filenames

### DIFF
--- a/src/parseo/schemas/copernicus/clms/n2k/n2k_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/n2k/n2k_filename_v1_0_0.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema_id": "copernicus:clms:n2k",
+  "schema_version": "1.0.0",
+  "status": "current",
+  "stac_version": "1.1.0",
+  "description": "Copernicus CLMS Natura 2000 (N2K) status and change layers filename (extension optional).",
+  "fields": {
+    "theme": {
+      "type": "string",
+      "enum": ["N2K", "N2K_Change"],
+      "description": "Dataset theme"
+    },
+    "reference": {
+      "type": "string",
+      "pattern": "^(?:2006|2012|2018|2006-2012|2012-2018)$",
+      "description": "Reference year or period"
+    },
+    "epsg_code": {
+      "type": "string",
+      "pattern": "^EPSG\\d{4,5}$",
+      "description": "EPSG code"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d+(?:_\\d+)*$",
+      "description": "Product version"
+    },
+    "extension": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9]+$",
+      "description": "File extension without leading dot"
+    }
+  },
+  "template": "{theme}_{reference}_{epsg_code}_{version}[.{extension}]",
+  "examples": [
+    "N2K_2018_EPSG3035_V1_0.gpkg",
+    "N2K_Change_2012-2018_EPSG3035_V2_0.zip"
+  ]
+}

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -87,3 +87,15 @@ def test_assemble_with_family_s2():
         == "S2B_MSIL2A_20241123T224759_N0511_R101_T03VUL_20241123T230829.SAFE"
     )
 
+
+def test_assemble_with_family_n2k():
+    fields = {
+        "theme": "N2K_Change",
+        "reference": "2012-2018",
+        "epsg_code": "EPSG3035",
+        "version": "V2_0",
+        "extension": "zip",
+    }
+    name = assemble(fields, family="N2K")
+    assert name == "N2K_Change_2012-2018_EPSG3035_V2_0.zip"
+

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -157,3 +157,23 @@ def test_parsing_fails_without_current(tmp_path, monkeypatch):
         parse_auto("ABC_X.txt")
     assert "current" in str(exc.value)
     schema_registry.clear_cache()
+
+
+def test_parse_n2k_status_and_change():
+    res_status = parse_auto("N2K_2018_EPSG3035_V1_0.gpkg")
+    assert res_status.valid
+    assert res_status.match_family == "N2K"
+    assert res_status.fields["theme"] == "N2K"
+    assert res_status.fields["reference"] == "2018"
+    assert res_status.fields["epsg_code"] == "EPSG3035"
+    assert res_status.fields["version"] == "V1_0"
+    assert res_status.fields["extension"] == "gpkg"
+
+    res_change = parse_auto("N2K_Change_2012-2018_EPSG3035_V2_0.zip")
+    assert res_change.valid
+    assert res_change.match_family == "N2K"
+    assert res_change.fields["theme"] == "N2K_Change"
+    assert res_change.fields["reference"] == "2012-2018"
+    assert res_change.fields["epsg_code"] == "EPSG3035"
+    assert res_change.fields["version"] == "V2_0"
+    assert res_change.fields["extension"] == "zip"


### PR DESCRIPTION
## Summary
- add a Copernicus CLMS Natura 2000 filename schema covering status and change layers
- exercise parsing and assembly of the new schema with dedicated tests

## Testing
- ruff check .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e1678cc5848327b1c1b8806edcf089