### PR TITLE
Disable CLMS type code preservation via value maps

### DIFF
--- a/src/parseo/schemas/copernicus/clms/clcplus/ras/clcplus_filename_v0_0_1.json
+++ b/src/parseo/schemas/copernicus/clms/clcplus/ras/clcplus_filename_v0_0_1.json
@@ -22,7 +22,6 @@
       "enum": ["RAS"],
       "description": "Data class code (raster)",
       "stac_map": {
-        "preserve_original_as": "type_code",
         "values": {
           "RAS": {"type": "raster"}
         }

--- a/src/parseo/schemas/copernicus/clms/urban-atlas/ua_dhm_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/urban-atlas/ua_dhm_filename_v0_0_0.json
@@ -27,7 +27,6 @@
       "enum": ["V"],
       "description": "Data type vector",
       "stac_map": {
-        "preserve_original_as": "type_code",
         "values": {
           "V": {"type": "vector"}
         }

--- a/src/parseo/schemas/copernicus/clms/urban-atlas/ua_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/urban-atlas/ua_filename_v0_0_0.json
@@ -32,7 +32,6 @@
       "enum": ["V","R"],
       "description": "Data type raster or vector",
       "stac_map": {
-        "preserve_original_as": "type_code",
         "values": {
           "V": {"type": "vector"},
           "R": {"type": "raster"}

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -171,7 +171,6 @@ def test_parse_urban_atlas_lcu():
         "variable": "LCU",
         "survey": "S2021",
         "type": "vector",
-        "type_code": "V",
         "resolution": "025ha",
         "area_code": "DK004L3",
         "city": "AALBORG",
@@ -181,6 +180,7 @@ def test_parse_urban_atlas_lcu():
         "production_date": "20240212",
         "extension": None,
     }
+    assert "type_code" not in result.fields
 
 
 def test_parse_clms_clcplus_type_mapping():
@@ -190,7 +190,7 @@ def test_parse_clms_clcplus_type_mapping():
     assert result.valid
     assert result.match_family == "RAS"
     assert result.fields["type"] == "raster"
-    assert result.fields["type_code"] == "RAS"
+    assert "type_code" not in result.fields
 
 
 


### PR DESCRIPTION
## Summary
- avoid preserving original tokens when a schema's STAC map relies on a nested `values` table so translations like CLMS type stay STAC-only
- drop redundant `preserve_original_as` entries from the CLMS CLC+ and Urban Atlas schemas now that value maps imply no preservation

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e24b3320f88327b1c9d95fdbc0408f