### PR TITLE
Update HR-VPP ST schema with additional examples

### DIFF
--- a/src/parseo/schemas/copernicus/clms/hr-vpp/st_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/st_filename_v0_0_0.json
@@ -10,7 +10,11 @@
     "product": {"type": "string", "enum": ["ST"], "description": "Constant prefix"},
     "timestamp": {"type": "string", "pattern": "^\\d{8}T\\d{6}$", "description": "Acquisition timestamp (YYYYMMDDTHHMMSS)"},
     "sensor": {"type": "string", "enum": ["S2"], "description": "Sensor platform"},
-    "eea_tile": {"type": "string", "pattern": "^[EW]\\d{2}[NS]\\d{2}$", "description": "Regional LAEA grid tile identifier"},
+    "eea_tile": {
+      "type": "string",
+      "pattern": "^([EW]\\d{2}[NS]\\d{2}|T\\d{2}[A-Z]{3})$",
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier"
+    },
     "epsg_code": {
       "type": "string",
       "pattern": "^\\d{4,5}$",
@@ -18,11 +22,18 @@
     },
     "resolution": {"type": "string", "pattern": "^\\d{3}m$", "description": "Spatial resolution"},
     "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "variable": {"type": "string", "enum": ["PPI"], "description": "Product code"},
+    "variable": {
+      "type": "string",
+      "enum": ["PPI", "QFLAG"],
+      "description": "Product code"
+    },
     "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
   },
-  "template": "{product}_{timestamp}_{sensor}_{eea_tile}[-{epsg_code}]_{resolution}_{version}_{variable}[.{extension}]",
+  "template": "{product}_{timestamp}_{sensor}_{eea_tile}[-{epsg_code}]-{resolution}_{version}_{variable}[.{extension}]",
   "examples": [
-    "ST_20240101T123045_S2_E15N45-3035_010m_V100_PPI.tif"
+    "ST_20170101T000000_S2_E10N25-03035-010m_V101_PPI.tif",
+    "ST_20170101T000000_S2_E10N25-03035-010m_V101_QFLAG.tif",
+    "ST_20170101T000000_S2_T20PPB-010m_V101_PPI.tif",
+    "ST_20170101T000000_S2_T20PPB-010m_V101_QFLAG.tif"
   ]
 }


### PR DESCRIPTION
## Summary
- align the ST filename template with the hyphenated resolution segment and document Sentinel-2 tile identifiers
- expand the product code enumeration to include both PPI and QFLAG values
- add the latest sample filenames to the schema examples list

## Testing
- ruff check .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e293b65c648327a511cf92053e8aae