### PR TITLE
Allow CLMS tile schemas to use discrete pattern options

### DIFF
--- a/src/parseo/_field_mappings.py
+++ b/src/parseo/_field_mappings.py
@@ -91,6 +91,11 @@ def _augment_with_tile_variants(fields: Dict[str, Any]) -> Dict[str, Any]:
         normalized = normalize_tile(value)
         enriched[candidate] = normalized
 
+        if "tile" not in enriched:
+            enriched["tile"] = normalized
+        if "tile_id" not in enriched:
+            enriched["tile_id"] = normalized
+
         if system is TileSystem.MGRS and "mgrs_tile" not in enriched:
             enriched["mgrs_tile"] = normalized
         if system is TileSystem.EEA and "eea_tile" not in enriched:
@@ -171,10 +176,10 @@ def translate_fields_to_tokens(
     """Translate STAC field values in *fields* back to schema tokens."""
 
     mappings = get_schema_field_mappings(schema)
-    if not mappings:
-        return fields
-
     translated = _augment_with_tile_variants(fields)
+
+    if not mappings:
+        return _backfill_tile_tokens(translated, schema)
     for field_name, mapping in mappings.items():
         token: Any = None
 

--- a/src/parseo/_tile_systems.py
+++ b/src/parseo/_tile_systems.py
@@ -1,0 +1,44 @@
+"""Helpers for recognizing spatial tile identifier systems."""
+
+from __future__ import annotations
+
+import re
+from enum import Enum
+from typing import Optional
+
+
+class TileSystem(str, Enum):
+    """Known spatial tiling systems."""
+
+    MGRS = "mgrs"
+    EEA = "eea"
+
+
+_MGRS_PATTERN = re.compile(r"^T\d{2}[C-HJ-NP-X][A-Z]{2}$")
+_EEA_PATTERN = re.compile(r"^[EW]\d{2,3}[NS]\d{2,3}$")
+
+
+def detect_tile_system(tile: str) -> Optional[TileSystem]:
+    """Return the :class:`TileSystem` matching *tile*, if any."""
+
+    if not isinstance(tile, str):
+        return None
+
+    candidate = tile.strip().upper()
+    if not candidate:
+        return None
+
+    if _MGRS_PATTERN.fullmatch(candidate):
+        return TileSystem.MGRS
+
+    if _EEA_PATTERN.fullmatch(candidate):
+        return TileSystem.EEA
+
+    return None
+
+
+def normalize_tile(tile: str) -> str:
+    """Return a normalised representation of *tile*."""
+
+    return tile.strip().upper()
+

--- a/src/parseo/schemas/copernicus/clms/clcplus/ras/clcplus_filename_v0_0_1.json
+++ b/src/parseo/schemas/copernicus/clms/clcplus/ras/clcplus_filename_v0_0_1.json
@@ -4,26 +4,37 @@
   "schema_version": "0.0.1",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS CLC+ raster product filename (extension optional).",
   "fields": {
     "programme": {
       "type": "string",
-      "enum": ["CLMS"],
+      "enum": [
+        "CLMS"
+      ],
       "description": "Copernicus Land Monitoring Service programme identifier"
     },
     "product": {
       "type": "string",
-      "enum": ["CLCPLUS"],
+      "enum": [
+        "CLCPLUS"
+      ],
       "description": "Product family identifier"
     },
     "type": {
       "type": "string",
-      "enum": ["RAS"],
+      "enum": [
+        "RAS"
+      ],
       "description": "Data class code (raster)",
       "stac_map": {
         "values": {
-          "RAS": {"type": "raster"}
+          "RAS": {
+            "type": "raster"
+          }
         }
       }
     },
@@ -39,8 +50,19 @@
     },
     "eea_tile": {
       "type": "string",
-      "pattern": "^[EW]\\d{2}[NS]\\d{2}$",
-      "description": "Tile identifier in the EEA 10m grid (easting/northing)"
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
     },
     "epsg_code": {
       "type": "string",
@@ -59,7 +81,9 @@
     },
     "extension": {
       "type": "string",
-      "enum": ["tif"],
+      "enum": [
+        "tif"
+      ],
       "description": "File extension without leading dot"
     }
   },

--- a/src/parseo/schemas/copernicus/clms/clcplus/ras/clcplus_filename_v0_0_1.json
+++ b/src/parseo/schemas/copernicus/clms/clcplus/ras/clcplus_filename_v0_0_1.json
@@ -48,7 +48,7 @@
       "pattern": "^R\\d{2}m$",
       "description": "Spatial resolution expressed with leading 'R' and units"
     },
-    "eea_tile": {
+    "tile_id": {
       "type": "string",
       "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
       "anyOf": [
@@ -87,7 +87,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "template": "{programme}_{product}_{type}_{season}_{resolution}_{eea_tile}_{epsg_code}_{version}_{revision}[.{extension}]",
+  "template": "{programme}_{product}_{type}_{season}_{resolution}_{tile_id}_{epsg_code}_{version}_{revision}[.{extension}]",
   "examples": [
     "CLMS_CLCPLUS_RAS_S2023_R10m_E48N37_03035_V01_R00.tif"
   ]

--- a/src/parseo/schemas/copernicus/clms/egms/egms_l3_velocity_grid_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/egms/egms_l3_velocity_grid_filename_v0_0_0.json
@@ -4,12 +4,16 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json"
+  ],
   "description": "Copernicus European Ground Motion Service Level 3 velocity grid filename (extension optional).",
   "fields": {
     "product": {
       "type": "string",
-      "enum": ["EGMS"],
+      "enum": [
+        "EGMS"
+      ],
       "description": "Constant service prefix"
     },
     "level": {
@@ -19,8 +23,19 @@
     },
     "tile": {
       "type": "string",
-      "pattern": "^E\\d{2,3}N\\d{2,3}$",
-      "description": "EGMS 100 km grid tile identifier"
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
     },
     "tile_size": {
       "type": "string",
@@ -49,7 +64,10 @@
     },
     "extension": {
       "type": "string",
-      "enum": ["tif", "tiff"],
+      "enum": [
+        "tif",
+        "tiff"
+      ],
       "description": "File extension without leading dot"
     }
   },

--- a/src/parseo/schemas/copernicus/clms/egms/egms_l3_velocity_grid_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/egms/egms_l3_velocity_grid_filename_v0_0_0.json
@@ -21,7 +21,7 @@
       "pattern": "^L[0-9]+$",
       "description": "Product processing level"
     },
-    "tile": {
+    "tile_id": {
       "type": "string",
       "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
       "anyOf": [
@@ -71,7 +71,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "template": "{product}_{level}_{tile}_{tile_size}_{component}_{start_year}_{end_year}_{version}[.{extension}]",
+  "template": "{product}_{level}_{tile_id}_{tile_size}_{component}_{start_year}_{end_year}_{version}[.{extension}]",
   "examples": [
     "EGMS_L3_E28N49_100km_U_2018_2022_1.tiff",
     "EGMS_L3_E37N28_100km_U_2019_2023_1.tiff"

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/st_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/st_filename_v0_0_0.json
@@ -29,7 +29,7 @@
       ],
       "description": "Sensor platform"
     },
-    "eea_tile": {
+    "tile_id": {
       "type": "string",
       "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
       "anyOf": [
@@ -76,7 +76,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "template": "{product}_{timestamp}_{sensor}_{eea_tile}[-{epsg_code}]-{resolution}_{version}_{variable}[.{extension}]",
+  "template": "{product}_{timestamp}_{sensor}_{tile_id}[-{epsg_code}]-{resolution}_{version}_{variable}[.{extension}]",
   "examples": [
     "ST_20170101T000000_S2_E10N25-03035-010m_V101_PPI.tif",
     "ST_20170101T000000_S2_E10N25-03035-010m_V101_QFLAG.tif",

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/st_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/st_filename_v0_0_0.json
@@ -4,30 +4,77 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS HR-VPP Seasonal Trajectories Plant Phenology Index product filename (extension optional).",
   "fields": {
-    "product": {"type": "string", "enum": ["ST"], "description": "Constant prefix"},
-    "timestamp": {"type": "string", "pattern": "^\\d{8}T\\d{6}$", "description": "Acquisition timestamp (YYYYMMDDTHHMMSS)"},
-    "sensor": {"type": "string", "enum": ["S2"], "description": "Sensor platform"},
+    "product": {
+      "type": "string",
+      "enum": [
+        "ST"
+      ],
+      "description": "Constant prefix"
+    },
+    "timestamp": {
+      "type": "string",
+      "pattern": "^\\d{8}T\\d{6}$",
+      "description": "Acquisition timestamp (YYYYMMDDTHHMMSS)"
+    },
+    "sensor": {
+      "type": "string",
+      "enum": [
+        "S2"
+      ],
+      "description": "Sensor platform"
+    },
     "eea_tile": {
       "type": "string",
-      "pattern": "^([EW]\\d{2}[NS]\\d{2}|T\\d{2}[A-Z]{3})$",
-      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier"
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
     },
     "epsg_code": {
       "type": "string",
       "pattern": "^\\d{4,5}$",
       "description": "EPSG code of the product grid (unpadded values are zero-filled on output)"
     },
-    "resolution": {"type": "string", "pattern": "^\\d{3}m$", "description": "Spatial resolution"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
+    "resolution": {
+      "type": "string",
+      "pattern": "^\\d{3}m$",
+      "description": "Spatial resolution"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
     "variable": {
       "type": "string",
-      "enum": ["PPI", "QFLAG"],
+      "enum": [
+        "PPI",
+        "QFLAG"
+      ],
       "description": "Product code"
     },
-    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{product}_{timestamp}_{sensor}_{eea_tile}[-{epsg_code}]-{resolution}_{version}_{variable}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/vi_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/vi_filename_v0_0_0.json
@@ -4,33 +4,60 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "Copernicus Land Monitoring Service Vegetation Index filename schema covering the HR-VPP suite (FAPAR, LAI, NDVI, PPI, FCOVER, DMP).",
   "fields": {
     "programme": {
       "type": "string",
-      "enum": ["CLMS"],
+      "enum": [
+        "CLMS"
+      ],
       "description": "Programme prefix (Copernicus Land Monitoring Service)"
     },
     "product": {
       "type": "string",
-      "enum": ["VPP"],
+      "enum": [
+        "VPP"
+      ],
       "description": "Product family identifier (Vegetation Phenology & Productivity)"
     },
     "parameter": {
       "type": "string",
-      "enum": ["FAPAR", "LAI", "NDVI", "PPI", "FCOVER", "DMP"],
+      "enum": [
+        "FAPAR",
+        "LAI",
+        "NDVI",
+        "PPI",
+        "FCOVER",
+        "DMP"
+      ],
       "description": "Biophysical variable encoded in the product"
     },
     "resolution": {
       "type": "string",
-      "enum": ["100m"],
+      "enum": [
+        "100m"
+      ],
       "description": "Spatial resolution of the raster"
     },
     "mgrs_tile": {
       "type": "string",
-      "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
-      "description": "MGRS tile identifier"
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
     },
     "start_date": {
       "type": "string",
@@ -49,12 +76,23 @@
     },
     "variable": {
       "type": "string",
-      "enum": ["FAPAR", "LAI", "NDVI", "PPI", "FCOVER", "DMP", "MTD"],
+      "enum": [
+        "FAPAR",
+        "LAI",
+        "NDVI",
+        "PPI",
+        "FCOVER",
+        "DMP",
+        "MTD"
+      ],
       "description": "Filename suffix indicating product content"
     },
     "extension": {
       "type": "string",
-      "enum": ["tif", "xml"],
+      "enum": [
+        "tif",
+        "xml"
+      ],
       "description": "File extension without leading dot"
     }
   },

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/vi_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/vi_filename_v0_0_0.json
@@ -43,7 +43,7 @@
       ],
       "description": "Spatial resolution of the raster"
     },
-    "mgrs_tile": {
+    "tile_id": {
       "type": "string",
       "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
       "anyOf": [
@@ -96,7 +96,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "template": "{programme}_{product}_{parameter}_{resolution}_{mgrs_tile}_{start_date}_{end_date}_{version}_{variable}[.{extension}]",
+  "template": "{programme}_{product}_{parameter}_{resolution}_{tile_id}_{start_date}_{end_date}_{version}_{variable}[.{extension}]",
   "examples": [
     "CLMS_VPP_FAPAR_100m_T32TNS_20210101_20210110_V100_FAPAR.tif",
     "CLMS_VPP_NDVI_100m_T32TNS_20210101_20210110_V100_NDVI.tif"

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/vpp_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/vpp_filename_v0_0_0.json
@@ -38,7 +38,7 @@
         }
       }
     },
-    "tile": {
+    "tile_id": {
       "type": "string",
       "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
       "anyOf": [
@@ -105,7 +105,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "template": "{product}_{reference_year}_{sensor}_{tile}[-{epsg_code}]-{resolution}_{version}_{season}_{variable}[.{extension}]",
+  "template": "{product}_{reference_year}_{sensor}_{tile_id}[-{epsg_code}]-{resolution}_{version}_{season}_{variable}[.{extension}]",
   "examples": [
     "VPP_2017_S2_T32TPR-010m_V101_s1_AMPL.tif",
     "VPP_2017_S2_E45N28-03035-010m_V101_s1_EOSD.tif",

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/vpp_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/vpp_filename_v0_0_0.json
@@ -12,7 +12,9 @@
   "fields": {
     "product": {
       "type": "string",
-      "enum": ["VPP"],
+      "enum": [
+        "VPP"
+      ],
       "description": "Product family prefix (Vegetation Phenology and Productivity)"
     },
     "reference_year": {
@@ -22,21 +24,36 @@
     },
     "sensor": {
       "type": "string",
-      "enum": ["S2"],
+      "enum": [
+        "S2"
+      ],
       "description": "Sensor platform",
       "stac_map": {
         "S2": {
           "platform": "Sentinel-2",
           "constellation": "Sentinel-2",
-          "instruments": ["MSI"]
+          "instruments": [
+            "MSI"
+          ]
         }
       }
     },
     "tile": {
       "type": "string",
-      "pattern": "^(?:T\\d{2}[C-HJ-NP-X][A-Z]{2}|[EW]\\d{2}[NS]\\d{2})$",
-      "description": "Sentinel-2 MGRS tile or EEA LAEA reference grid cell identifier"
-    },    
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
+    },
     "epsg_code": {
       "type": "string",
       "pattern": "^\\d{4,5}$",
@@ -54,7 +71,10 @@
     },
     "season": {
       "type": "string",
-      "enum": ["s1", "s2"],
+      "enum": [
+        "s1",
+        "s2"
+      ],
       "description": "Season identifier (s1 = first season, s2 = second season)"
     },
     "variable": {
@@ -79,7 +99,9 @@
     },
     "extension": {
       "type": "string",
-      "enum": ["tif"],
+      "enum": [
+        "tif"
+      ],
       "description": "File extension without leading dot"
     }
   },

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/cc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/cc_filename_v0_0_0.json
@@ -38,7 +38,7 @@
       ],
       "description": "Pixel spacing"
     },
-    "mgrs_tile": {
+    "tile_id": {
       "type": "string",
       "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
       "anyOf": [
@@ -92,7 +92,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "template": "{programme}_{project}_{product}_{pixel_spacing}_{mgrs_tile}_{sensing_datetime}_{platform}_{version}_{variable}[.{extension}]",
+  "template": "{programme}_{project}_{product}_{pixel_spacing}_{tile_id}_{sensing_datetime}_{platform}_{version}_{variable}[.{extension}]",
   "examples": [
     "CLMS_WSI_CC_020m_T32TNS_20211018T103021_S2A_V100_CC.tif"
   ]

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/cc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/cc_filename_v0_0_0.json
@@ -4,27 +4,93 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS HR-WSI Cloud Cover product filename (extension optional).",
   "fields": {
     "programme": {
       "type": "string",
-      "enum": ["CLMS"],
+      "enum": [
+        "CLMS"
+      ],
       "description": "Constant programme prefix"
     },
     "project": {
-      "type": "string", 
-      "enum": ["WSI"], 
+      "type": "string",
+      "enum": [
+        "WSI"
+      ],
       "description": "Project"
-  },
-    "product": {"type": "string", "enum": ["CC"], "description": "Product code"},
-    "pixel_spacing": {"type": "string", "enum": ["020m"], "description": "Pixel spacing"},
-    "mgrs_tile": {"type": "string", "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$", "description": "MGRS tile identifier"},
-    "sensing_datetime": {"type": "string", "pattern": "^\\d{8}T\\d{6}$", "description": "Acquisition datetime (UTC)"},
-    "platform": {"type": "string", "enum": ["S2A", "S2B", "S2C"], "description": "Satellite platform"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "variable": {"type": "string", "enum": ["CC", "CC-QA", "QAFLAGS", "MTD"], "description": "File identifier"},
-    "extension": {"type": "string", "enum": ["tif", "xml"], "description": "File extension without leading dot"}
+    },
+    "product": {
+      "type": "string",
+      "enum": [
+        "CC"
+      ],
+      "description": "Product code"
+    },
+    "pixel_spacing": {
+      "type": "string",
+      "enum": [
+        "020m"
+      ],
+      "description": "Pixel spacing"
+    },
+    "mgrs_tile": {
+      "type": "string",
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
+    },
+    "sensing_datetime": {
+      "type": "string",
+      "pattern": "^\\d{8}T\\d{6}$",
+      "description": "Acquisition datetime (UTC)"
+    },
+    "platform": {
+      "type": "string",
+      "enum": [
+        "S2A",
+        "S2B",
+        "S2C"
+      ],
+      "description": "Satellite platform"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "variable": {
+      "type": "string",
+      "enum": [
+        "CC",
+        "CC-QA",
+        "QAFLAGS",
+        "MTD"
+      ],
+      "description": "File identifier"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif",
+        "xml"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{programme}_{project}_{product}_{pixel_spacing}_{mgrs_tile}_{sensing_datetime}_{platform}_{version}_{variable}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/fsc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/fsc_filename_v0_0_0.json
@@ -38,7 +38,7 @@
       ],
       "description": "Pixel spacing"
     },
-    "mgrs_tile": {
+    "tile_id": {
       "type": "string",
       "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
       "anyOf": [
@@ -96,7 +96,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "template": "{programme}_{project}_{product}_{pixel_spacing}_{mgrs_tile}_{sensing_datetime}_{platform}_{version}_{variable}[.{extension}]",
+  "template": "{programme}_{project}_{product}_{pixel_spacing}_{tile_id}_{sensing_datetime}_{platform}_{version}_{variable}[.{extension}]",
   "examples": [
     "CLMS_WSI_FSC_020m_T32TNS_20211018T103021_S2A_V100_FSCOG.tif"
   ]

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/fsc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/fsc_filename_v0_0_0.json
@@ -4,25 +4,75 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS HR-WSI Fractional Snow Cover product filename (extension optional).",
   "fields": {
     "programme": {
       "type": "string",
-      "enum": ["CLMS"],
+      "enum": [
+        "CLMS"
+      ],
       "description": "Constant programme prefix"
     },
     "project": {
-      "type": "string", 
-      "enum": ["WSI"], 
+      "type": "string",
+      "enum": [
+        "WSI"
+      ],
       "description": "Project"
-    },    
-    "product": {"type": "string", "enum": ["FSC"], "description": "Product code"},
-    "pixel_spacing": {"type": "string", "enum": ["020m"], "description": "Pixel spacing"},
-    "mgrs_tile": {"type": "string", "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$", "description": "MGRS tile identifier"},
-    "sensing_datetime": {"type": "string", "pattern": "^\\d{8}T\\d{6}$", "description": "Acquisition datetime (UTC)"},
-    "platform": {"type": "string", "enum": ["S2A", "S2B", "S2C"], "description": "Satellite platform"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
+    },
+    "product": {
+      "type": "string",
+      "enum": [
+        "FSC"
+      ],
+      "description": "Product code"
+    },
+    "pixel_spacing": {
+      "type": "string",
+      "enum": [
+        "020m"
+      ],
+      "description": "Pixel spacing"
+    },
+    "mgrs_tile": {
+      "type": "string",
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
+    },
+    "sensing_datetime": {
+      "type": "string",
+      "pattern": "^\\d{8}T\\d{6}$",
+      "description": "Acquisition datetime (UTC)"
+    },
+    "platform": {
+      "type": "string",
+      "enum": [
+        "S2A",
+        "S2B",
+        "S2C"
+      ],
+      "description": "Satellite platform"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
     "variable": {
       "type": "string",
       "enum": [
@@ -37,7 +87,14 @@
       ],
       "description": "File identifier"
     },
-    "extension": {"type": "string", "enum": ["tif", "xml"], "description": "File extension without leading dot"}
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif",
+        "xml"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{programme}_{project}_{product}_{pixel_spacing}_{mgrs_tile}_{sensing_datetime}_{platform}_{version}_{variable}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/gfsc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/gfsc_filename_v0_0_0.json
@@ -38,7 +38,7 @@
       ],
       "description": "Pixel spacing"
     },
-    "mgrs_tile": {
+    "tile_id": {
       "type": "string",
       "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
       "anyOf": [
@@ -91,7 +91,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "template": "{programme}_{project}_{product}_{pixel_spacing}_{mgrs_tile}_{period}_{combination}_{version}_{variable}[.{extension}]",
+  "template": "{programme}_{project}_{product}_{pixel_spacing}_{tile_id}_{period}_{combination}_{version}_{variable}[.{extension}]",
   "examples": [
     "CLMS_WSI_GFSC_060m_T32TNS_20211018P7D_COMB_V100_GF-QA.tif"
   ]

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/gfsc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/gfsc_filename_v0_0_0.json
@@ -4,31 +4,92 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS HR-WSI Gap-filled Fractional Snow Cover product filename (extension optional).",
   "fields": {
     "programme": {
       "type": "string",
-      "enum": ["CLMS"],
+      "enum": [
+        "CLMS"
+      ],
       "description": "Constant programme prefix"
     },
     "project": {
       "type": "string",
-      "enum": ["WSI"],
+      "enum": [
+        "WSI"
+      ],
       "description": "Project"
     },
-    "product": {"type": "string", "enum": ["GFSC"], "description": "Product code"},
-    "pixel_spacing": {"type": "string", "enum": ["060m"], "description": "Pixel spacing"},
-    "mgrs_tile": {"type": "string", "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$", "description": "MGRS tile identifier"},
-    "period": {"type": "string", "pattern": "^\\d{8}P7D$", "description": "Aggregation period"},
-    "combination": {"type": "string", "enum": ["COMB"], "description": "Combination method"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
+    "product": {
+      "type": "string",
+      "enum": [
+        "GFSC"
+      ],
+      "description": "Product code"
+    },
+    "pixel_spacing": {
+      "type": "string",
+      "enum": [
+        "060m"
+      ],
+      "description": "Pixel spacing"
+    },
+    "mgrs_tile": {
+      "type": "string",
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
+    },
+    "period": {
+      "type": "string",
+      "pattern": "^\\d{8}P7D$",
+      "description": "Aggregation period"
+    },
+    "combination": {
+      "type": "string",
+      "enum": [
+        "COMB"
+      ],
+      "description": "Combination method"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
     "variable": {
       "type": "string",
-      "enum": ["AT", "GF", "GF-QA", "MTD", "QAFLAGS"],
+      "enum": [
+        "AT",
+        "GF",
+        "GF-QA",
+        "MTD",
+        "QAFLAGS"
+      ],
       "description": "File identifier"
     },
-    "extension": {"type": "string", "enum": ["tif", "xml"], "description": "File extension without leading dot"}
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif",
+        "xml"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{programme}_{project}_{product}_{pixel_spacing}_{mgrs_tile}_{period}_{combination}_{version}_{variable}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/icd_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/icd_filename_v0_0_0.json
@@ -4,27 +4,93 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS HR-WSI Ice Cover Duration product filename (extension optional).",
   "fields": {
     "programme": {
       "type": "string",
-      "enum": ["CLMS"],
+      "enum": [
+        "CLMS"
+      ],
       "description": "Constant programme prefix"
     },
     "project": {
       "type": "string",
-      "enum": ["WSI"],
+      "enum": [
+        "WSI"
+      ],
       "description": "Project"
     },
-    "product": {"type": "string", "enum": ["ICD"], "description": "Product code"},
-    "pixel_spacing": {"type": "string", "enum": ["020m", "100m"], "description": "Pixel spacing"},
-    "tile_id": {"type": "string", "pattern": "^(?:T\\d{2}[C-HJ-NP-X][A-Z]{2}|E\\d{2}N\\d{2})$", "description": "Tile identifier"},
-    "period_start": {"type": "string", "pattern": "^\\d{8}P1Y$", "description": "Aggregation period start"},
-    "combination": {"type": "string", "enum": ["COMB"], "description": "Combination method"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "variable": {"type": "string", "enum": ["ICD", "NOBS1", "NOBS2", "ICD-QA", "MTD"], "description": "File identifier"},
-    "extension": {"type": "string", "enum": ["tif", "xml"], "description": "File extension without leading dot"}
+    "product": {
+      "type": "string",
+      "enum": [
+        "ICD"
+      ],
+      "description": "Product code"
+    },
+    "pixel_spacing": {
+      "type": "string",
+      "enum": [
+        "020m",
+        "100m"
+      ],
+      "description": "Pixel spacing"
+    },
+    "tile_id": {
+      "type": "string",
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
+    },
+    "period_start": {
+      "type": "string",
+      "pattern": "^\\d{8}P1Y$",
+      "description": "Aggregation period start"
+    },
+    "combination": {
+      "type": "string",
+      "enum": [
+        "COMB"
+      ],
+      "description": "Combination method"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "variable": {
+      "type": "string",
+      "enum": [
+        "ICD",
+        "NOBS1",
+        "NOBS2",
+        "ICD-QA",
+        "MTD"
+      ],
+      "description": "File identifier"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif",
+        "xml"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{programme}_{project}_{product}_{pixel_spacing}_{tile_id}_{period_start}_{combination}_{version}_{variable}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/sp_comb_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/sp_comb_filename_v0_0_0.json
@@ -4,27 +4,98 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS HR-WSI Snow Products combination filename (extension optional).",
   "fields": {
     "programme": {
       "type": "string",
-      "enum": ["CLMS"],
+      "enum": [
+        "CLMS"
+      ],
       "description": "Constant programme prefix"
     },
     "project": {
       "type": "string",
-      "enum": ["WSI"],
+      "enum": [
+        "WSI"
+      ],
       "description": "Project"
     },
-    "product": {"type": "string", "enum": ["SP"], "description": "Product code"},
-    "pixel_spacing": {"type": "string", "enum": ["060m", "100m"], "description": "Pixel spacing"},
-    "tile_id": {"type": "string", "pattern": "^(?:T\\d{2}[C-HJ-NP-X][A-Z]{2}|E\\d{2}N\\d{2})$", "description": "Tile identifier"},
-    "period_start": {"type": "string", "pattern": "^\\d{8}P1Y$", "description": "Aggregation period start"},
-    "combination": {"type": "string", "enum": ["COMB"], "description": "Combination method"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "variable": {"type": "string", "enum": ["SCD", "SCO", "SCM", "NCSO", "NWSO", "QAFLAGS", "SCD-QA", "SCO-QA", "SCM-QA", "MTD"], "description": "File identifier"},
-    "extension": {"type": "string", "enum": ["tif", "xml"], "description": "File extension without leading dot"}
+    "product": {
+      "type": "string",
+      "enum": [
+        "SP"
+      ],
+      "description": "Product code"
+    },
+    "pixel_spacing": {
+      "type": "string",
+      "enum": [
+        "060m",
+        "100m"
+      ],
+      "description": "Pixel spacing"
+    },
+    "tile_id": {
+      "type": "string",
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
+    },
+    "period_start": {
+      "type": "string",
+      "pattern": "^\\d{8}P1Y$",
+      "description": "Aggregation period start"
+    },
+    "combination": {
+      "type": "string",
+      "enum": [
+        "COMB"
+      ],
+      "description": "Combination method"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "variable": {
+      "type": "string",
+      "enum": [
+        "SCD",
+        "SCO",
+        "SCM",
+        "NCSO",
+        "NWSO",
+        "QAFLAGS",
+        "SCD-QA",
+        "SCO-QA",
+        "SCM-QA",
+        "MTD"
+      ],
+      "description": "File identifier"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif",
+        "xml"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{programme}_{project}_{product}_{pixel_spacing}_{tile_id}_{period_start}_{combination}_{version}_{variable}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/sp_s2_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/sp_s2_filename_v0_0_0.json
@@ -4,27 +4,97 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS HR-WSI Snow Products Sentinel-2 source filename (extension optional).",
   "fields": {
     "programme": {
       "type": "string",
-      "enum": ["CLMS"],
+      "enum": [
+        "CLMS"
+      ],
       "description": "Constant programme prefix"
     },
     "project": {
       "type": "string",
-      "enum": ["WSI"],
+      "enum": [
+        "WSI"
+      ],
       "description": "Project"
     },
-    "product": {"type": "string", "enum": ["SP"], "description": "Product code"},
-    "pixel_spacing": {"type": "string", "enum": ["020m", "100m"], "description": "Pixel spacing"},
-    "tile_id": {"type": "string", "pattern": "^(?:T\\d{2}[C-HJ-NP-X][A-Z]{2}|E\\d{2}N\\d{2})$", "description": "Tile identifier"},
-    "period_start": {"type": "string", "pattern": "^\\d{8}P1Y$", "description": "Aggregation period start"},
-    "source": {"type": "string", "enum": ["S2"], "description": "Source mission"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "variable": {"type": "string", "enum": ["SCD", "SCO", "SCM", "NOBS", "QAFLAGS", "SCD-QA", "SCO-QA", "SCM-QA", "MTD"], "description": "File identifier"},
-    "extension": {"type": "string", "enum": ["tif", "xml"], "description": "File extension without leading dot"}
+    "product": {
+      "type": "string",
+      "enum": [
+        "SP"
+      ],
+      "description": "Product code"
+    },
+    "pixel_spacing": {
+      "type": "string",
+      "enum": [
+        "020m",
+        "100m"
+      ],
+      "description": "Pixel spacing"
+    },
+    "tile_id": {
+      "type": "string",
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
+    },
+    "period_start": {
+      "type": "string",
+      "pattern": "^\\d{8}P1Y$",
+      "description": "Aggregation period start"
+    },
+    "source": {
+      "type": "string",
+      "enum": [
+        "S2"
+      ],
+      "description": "Source mission"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "variable": {
+      "type": "string",
+      "enum": [
+        "SCD",
+        "SCO",
+        "SCM",
+        "NOBS",
+        "QAFLAGS",
+        "SCD-QA",
+        "SCO-QA",
+        "SCM-QA",
+        "MTD"
+      ],
+      "description": "File identifier"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif",
+        "xml"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{programme}_{project}_{product}_{pixel_spacing}_{tile_id}_{period_start}_{source}_{version}_{variable}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/sws_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/sws_filename_v0_0_0.json
@@ -4,27 +4,92 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS HR-WSI Small Water Surface product filename (extension optional).",
   "fields": {
     "programme": {
       "type": "string",
-      "enum": ["CLMS"],
+      "enum": [
+        "CLMS"
+      ],
       "description": "Constant programme prefix"
     },
     "project": {
       "type": "string",
-      "enum": ["WSI"],
+      "enum": [
+        "WSI"
+      ],
       "description": "Project"
     },
-    "product": {"type": "string", "enum": ["SWS"], "description": "Product code"},
-    "pixel_spacing": {"type": "string", "enum": ["060m"], "description": "Pixel spacing"},
-    "mgrs_tile": {"type": "string", "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$", "description": "MGRS tile identifier"},
-    "sensing_datetime": {"type": "string", "pattern": "^\\d{8}T\\d{6}$", "description": "Acquisition datetime (UTC)"},
-    "platform": {"type": "string", "enum": ["S1A", "S1B", "S1C"], "description": "Satellite platform"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "variable": {"type": "string", "enum": ["WSM", "WSM-QA", "MTD"], "description": "File identifier"},
-    "extension": {"type": "string", "enum": ["tif", "xml"], "description": "File extension without leading dot"}
+    "product": {
+      "type": "string",
+      "enum": [
+        "SWS"
+      ],
+      "description": "Product code"
+    },
+    "pixel_spacing": {
+      "type": "string",
+      "enum": [
+        "060m"
+      ],
+      "description": "Pixel spacing"
+    },
+    "mgrs_tile": {
+      "type": "string",
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
+    },
+    "sensing_datetime": {
+      "type": "string",
+      "pattern": "^\\d{8}T\\d{6}$",
+      "description": "Acquisition datetime (UTC)"
+    },
+    "platform": {
+      "type": "string",
+      "enum": [
+        "S1A",
+        "S1B",
+        "S1C"
+      ],
+      "description": "Satellite platform"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "variable": {
+      "type": "string",
+      "enum": [
+        "WSM",
+        "WSM-QA",
+        "MTD"
+      ],
+      "description": "File identifier"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif",
+        "xml"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{programme}_{project}_{product}_{pixel_spacing}_{mgrs_tile}_{sensing_datetime}_{platform}_{version}_{variable}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/sws_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/sws_filename_v0_0_0.json
@@ -38,7 +38,7 @@
       ],
       "description": "Pixel spacing"
     },
-    "mgrs_tile": {
+    "tile_id": {
       "type": "string",
       "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
       "anyOf": [
@@ -91,7 +91,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "template": "{programme}_{project}_{product}_{pixel_spacing}_{mgrs_tile}_{sensing_datetime}_{platform}_{version}_{variable}[.{extension}]",
+  "template": "{programme}_{project}_{product}_{pixel_spacing}_{tile_id}_{sensing_datetime}_{platform}_{version}_{variable}[.{extension}]",
   "examples": [
     "CLMS_WSI_SWS_060m_T32TNS_20210217T053159_S1B_V100_WSM.tif"
   ]

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/wds_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/wds_filename_v0_0_0.json
@@ -38,7 +38,7 @@
       ],
       "description": "Pixel spacing"
     },
-    "mgrs_tile": {
+    "tile_id": {
       "type": "string",
       "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
       "anyOf": [
@@ -91,7 +91,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "template": "{programme}_{project}_{product}_{pixel_spacing}_{mgrs_tile}_{sensing_datetime}_{platform}_{version}_{variable}[.{extension}]",
+  "template": "{programme}_{project}_{product}_{pixel_spacing}_{tile_id}_{sensing_datetime}_{platform}_{version}_{variable}[.{extension}]",
   "examples": [
     "CLMS_WSI_WDS_060m_T32TNS_20210217T053159_S1B_V100_SSC.tif"
   ]

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/wds_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/wds_filename_v0_0_0.json
@@ -4,27 +4,92 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS HR-WSI Water Detection and Surface Displacement product filename (extension optional).",
   "fields": {
     "programme": {
       "type": "string",
-      "enum": ["CLMS"],
+      "enum": [
+        "CLMS"
+      ],
       "description": "Constant programme prefix"
     },
     "project": {
       "type": "string",
-      "enum": ["WSI"],
+      "enum": [
+        "WSI"
+      ],
       "description": "Project"
     },
-    "product": {"type": "string", "enum": ["WDS"], "description": "Product code"},
-    "pixel_spacing": {"type": "string", "enum": ["060m"], "description": "Pixel spacing"},
-    "mgrs_tile": {"type": "string", "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$", "description": "MGRS tile identifier"},
-    "sensing_datetime": {"type": "string", "pattern": "^\\d{8}T\\d{6}$", "description": "Acquisition datetime (UTC)"},
-    "platform": {"type": "string", "enum": ["S1A", "S1B", "S1C"], "description": "Satellite platform"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "variable": {"type": "string", "enum": ["SSC", "SSC-QA", "MTD"], "description": "File identifier"},
-    "extension": {"type": "string", "enum": ["tif", "xml"], "description": "File extension without leading dot"}
+    "product": {
+      "type": "string",
+      "enum": [
+        "WDS"
+      ],
+      "description": "Product code"
+    },
+    "pixel_spacing": {
+      "type": "string",
+      "enum": [
+        "060m"
+      ],
+      "description": "Pixel spacing"
+    },
+    "mgrs_tile": {
+      "type": "string",
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
+    },
+    "sensing_datetime": {
+      "type": "string",
+      "pattern": "^\\d{8}T\\d{6}$",
+      "description": "Acquisition datetime (UTC)"
+    },
+    "platform": {
+      "type": "string",
+      "enum": [
+        "S1A",
+        "S1B",
+        "S1C"
+      ],
+      "description": "Satellite platform"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "variable": {
+      "type": "string",
+      "enum": [
+        "SSC",
+        "SSC-QA",
+        "MTD"
+      ],
+      "description": "File identifier"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif",
+        "xml"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{programme}_{project}_{product}_{pixel_spacing}_{mgrs_tile}_{sensing_datetime}_{platform}_{version}_{variable}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/wic_comb_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/wic_comb_filename_v0_0_0.json
@@ -38,7 +38,7 @@
       ],
       "description": "Pixel spacing"
     },
-    "mgrs_tile": {
+    "tile_id": {
       "type": "string",
       "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
       "anyOf": [
@@ -90,7 +90,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "template": "{programme}_{project}_{product}_{pixel_spacing}_{mgrs_tile}_{period_start}_{combination}_{version}_{variable}[.{extension}]",
+  "template": "{programme}_{project}_{product}_{pixel_spacing}_{tile_id}_{period_start}_{combination}_{version}_{variable}[.{extension}]",
   "examples": [
     "CLMS_WSI_WIC_020m_T31TCH_20160720T120000P12H_COMB_V100_WIC-QA.tif"
   ]

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/wic_comb_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/wic_comb_filename_v0_0_0.json
@@ -4,27 +4,91 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS HR-WSI Water and Ice Cover combination filename (extension optional).",
   "fields": {
     "programme": {
       "type": "string",
-      "enum": ["CLMS"],
+      "enum": [
+        "CLMS"
+      ],
       "description": "Constant programme prefix"
     },
     "project": {
       "type": "string",
-      "enum": ["WSI"],
+      "enum": [
+        "WSI"
+      ],
       "description": "Project"
     },
-    "product": {"type": "string", "enum": ["WIC"], "description": "Product code"},
-    "pixel_spacing": {"type": "string", "enum": ["020m"], "description": "Pixel spacing"},
-    "mgrs_tile": {"type": "string", "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$", "description": "MGRS tile identifier"},
-    "period_start": {"type": "string", "pattern": "^\\d{8}T(?:00|12)0000P12H$", "description": "Aggregation period start"},
-    "combination": {"type": "string", "enum": ["COMB"], "description": "Combination method"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "variable": {"type": "string", "enum": ["WIC", "QAFLAGS", "WIC-QA", "MTD"], "description": "File identifier"},
-    "extension": {"type": "string", "enum": ["tif", "xml"], "description": "File extension without leading dot"}
+    "product": {
+      "type": "string",
+      "enum": [
+        "WIC"
+      ],
+      "description": "Product code"
+    },
+    "pixel_spacing": {
+      "type": "string",
+      "enum": [
+        "020m"
+      ],
+      "description": "Pixel spacing"
+    },
+    "mgrs_tile": {
+      "type": "string",
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
+    },
+    "period_start": {
+      "type": "string",
+      "pattern": "^\\d{8}T(?:00|12)0000P12H$",
+      "description": "Aggregation period start"
+    },
+    "combination": {
+      "type": "string",
+      "enum": [
+        "COMB"
+      ],
+      "description": "Combination method"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "variable": {
+      "type": "string",
+      "enum": [
+        "WIC",
+        "QAFLAGS",
+        "WIC-QA",
+        "MTD"
+      ],
+      "description": "File identifier"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif",
+        "xml"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{programme}_{project}_{product}_{pixel_spacing}_{mgrs_tile}_{period_start}_{combination}_{version}_{variable}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/wic_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/wic_filename_v0_0_0.json
@@ -39,7 +39,7 @@
       ],
       "description": "Pixel spacing"
     },
-    "mgrs_tile": {
+    "tile_id": {
       "type": "string",
       "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
       "anyOf": [
@@ -97,7 +97,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "template": "{programme}_{project}_{product}_{pixel_spacing}_{mgrs_tile}_{sensing_datetime}_{platform}_{version}_{variable}[.{extension}]",
+  "template": "{programme}_{project}_{product}_{pixel_spacing}_{tile_id}_{sensing_datetime}_{platform}_{version}_{variable}[.{extension}]",
   "examples": [
     "CLMS_WSI_WIC_020m_T31TCH_20160720T105547_S2A_V100_WIC-QA.tif",
     "CLMS_WSI_WIC_060m_T34UEG_20170214T044301_S1A_V100_WIC.tif"

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/wic_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/wic_filename_v0_0_0.json
@@ -4,27 +4,98 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS HR-WSI Water and Ice Cover Sentinel-1 and Sentinel-2 product filename (extension optional).",
   "fields": {
     "programme": {
       "type": "string",
-      "enum": ["CLMS"],
+      "enum": [
+        "CLMS"
+      ],
       "description": "Constant programme prefix"
     },
     "project": {
       "type": "string",
-      "enum": ["WSI"],
+      "enum": [
+        "WSI"
+      ],
       "description": "Project"
     },
-    "product": {"type": "string", "enum": ["WIC"], "description": "Product code"},
-    "pixel_spacing": {"type": "string", "enum": ["020m", "060m"], "description": "Pixel spacing"},
-    "mgrs_tile": {"type": "string", "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$", "description": "MGRS tile identifier"},
-    "sensing_datetime": {"type": "string", "pattern": "^\\d{8}T\\d{6}$", "description": "Acquisition datetime (UTC)"},
-    "platform": {"type": "string", "enum": ["S1A", "S1B", "S1C", "S2A", "S2B", "S2C"], "description": "Satellite platform"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "variable": {"type": "string", "enum": ["WIC", "PRB", "QAFLAGS", "WIC-QA", "MTD"], "description": "File identifier"},
-    "extension": {"type": "string", "enum": ["tif", "xml"], "description": "File extension without leading dot"}
+    "product": {
+      "type": "string",
+      "enum": [
+        "WIC"
+      ],
+      "description": "Product code"
+    },
+    "pixel_spacing": {
+      "type": "string",
+      "enum": [
+        "020m",
+        "060m"
+      ],
+      "description": "Pixel spacing"
+    },
+    "mgrs_tile": {
+      "type": "string",
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
+    },
+    "sensing_datetime": {
+      "type": "string",
+      "pattern": "^\\d{8}T\\d{6}$",
+      "description": "Acquisition datetime (UTC)"
+    },
+    "platform": {
+      "type": "string",
+      "enum": [
+        "S1A",
+        "S1B",
+        "S1C",
+        "S2A",
+        "S2B",
+        "S2C"
+      ],
+      "description": "Satellite platform"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "variable": {
+      "type": "string",
+      "enum": [
+        "WIC",
+        "PRB",
+        "QAFLAGS",
+        "WIC-QA",
+        "MTD"
+      ],
+      "description": "File identifier"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif",
+        "xml"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{programme}_{project}_{product}_{pixel_spacing}_{mgrs_tile}_{sensing_datetime}_{platform}_{version}_{variable}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hrl/fty_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/fty_filename_v0_0_0.json
@@ -22,7 +22,7 @@
       "pattern": "^\\d{4}$",
       "description": "Reference year"
     },
-    "eea_tile": {
+    "tile_id": {
       "type": "string",
       "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
       "anyOf": [
@@ -56,7 +56,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "template": "{variable}_{reference_year}_{eea_tile}_{resolution}_{version}[.{extension}]",
+  "template": "{variable}_{reference_year}_{tile_id}_{resolution}_{version}[.{extension}]",
   "examples": [
     "FTY_2018_E042N018_010m_V100.tif"
   ]

--- a/src/parseo/schemas/copernicus/clms/hrl/fty_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/fty_filename_v0_0_0.json
@@ -4,15 +4,57 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS High Resolution Layer Forest Type product filename (extension optional).",
   "fields": {
-    "variable": {"type": "string", "enum": ["FTY"], "description": "Product code"},
-    "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
-    "eea_tile": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA, LAEA reference grid tile identifier"},
-    "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+    "variable": {
+      "type": "string",
+      "enum": [
+        "FTY"
+      ],
+      "description": "Product code"
+    },
+    "reference_year": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "Reference year"
+    },
+    "eea_tile": {
+      "type": "string",
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
+    },
+    "resolution": {
+      "type": "string",
+      "pattern": "^(010m|020m|100m)$",
+      "description": "Spatial resolution"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{variable}_{reference_year}_{eea_tile}_{resolution}_{version}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hrl/gra_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/gra_filename_v0_0_0.json
@@ -22,7 +22,7 @@
       "pattern": "^\\d{4}$",
       "description": "Reference year"
     },
-    "eea_tile": {
+    "tile_id": {
       "type": "string",
       "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
       "anyOf": [
@@ -56,7 +56,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "template": "{variable}_{reference_year}_{eea_tile}_{resolution}_{version}[.{extension}]",
+  "template": "{variable}_{reference_year}_{tile_id}_{resolution}_{version}[.{extension}]",
   "examples": [
     "GRA_2018_E042N018_010m_V100.tif"
   ]

--- a/src/parseo/schemas/copernicus/clms/hrl/gra_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/gra_filename_v0_0_0.json
@@ -4,15 +4,57 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS High Resolution Layer Grassland product filename (extension optional).",
   "fields": {
-    "variable": {"type": "string", "enum": ["GRA"], "description": "Product code"},
-    "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
-    "eea_tile": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA, LAEA reference grid tile identifier"},
-    "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+    "variable": {
+      "type": "string",
+      "enum": [
+        "GRA"
+      ],
+      "description": "Product code"
+    },
+    "reference_year": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "Reference year"
+    },
+    "eea_tile": {
+      "type": "string",
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
+    },
+    "resolution": {
+      "type": "string",
+      "pattern": "^(010m|020m|100m)$",
+      "description": "Spatial resolution"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{variable}_{reference_year}_{eea_tile}_{resolution}_{version}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hrl/ibu_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/ibu_filename_v0_0_0.json
@@ -27,7 +27,7 @@
       "pattern": "^\\d{3}m$",
       "description": "Spatial resolution in metres with leading zeros"
     },
-    "eea_tile": {
+    "tile_id": {
       "type": "string",
       "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
       "anyOf": [
@@ -61,7 +61,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "template": "{variable}_{reference_year}_{resolution}_{eea_tile}_{epsg_code}_{version}[.{extension}]",
+  "template": "{variable}_{reference_year}_{resolution}_{tile_id}_{epsg_code}_{version}[.{extension}]",
   "examples": [
     "IBU_2018_010m_E47N18_03035_v010.tif",
     "IBU_2018_010m_E47N19_03035_v010.tif",

--- a/src/parseo/schemas/copernicus/clms/hrl/ibu_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/ibu_filename_v0_0_0.json
@@ -4,16 +4,62 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS High Resolution Layer Impervious Built-up Area product filename (extension optional).",
   "fields": {
-    "variable": {"type": "string", "enum": ["IBU"], "description": "Product code"},
-    "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
-    "resolution": {"type": "string", "pattern": "^\\d{3}m$", "description": "Spatial resolution in metres with leading zeros"},
-    "eea_tile": {"type": "string", "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$", "description": "EEA reference grid tile identifier"},
-    "epsg_code": {"type": "string", "pattern": "^\\d{5}$", "description": "EPSG code of the product grid"},
-    "version": {"type": "string", "pattern": "^v\\d{3}$", "description": "Product version"},
-    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+    "variable": {
+      "type": "string",
+      "enum": [
+        "IBU"
+      ],
+      "description": "Product code"
+    },
+    "reference_year": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "Reference year"
+    },
+    "resolution": {
+      "type": "string",
+      "pattern": "^\\d{3}m$",
+      "description": "Spatial resolution in metres with leading zeros"
+    },
+    "eea_tile": {
+      "type": "string",
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
+    },
+    "epsg_code": {
+      "type": "string",
+      "pattern": "^\\d{5}$",
+      "description": "EPSG code of the product grid"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^v\\d{3}$",
+      "description": "Product version"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{variable}_{reference_year}_{resolution}_{eea_tile}_{epsg_code}_{version}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hrl/imp_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/imp_filename_v0_0_0.json
@@ -22,7 +22,7 @@
       "pattern": "^\\d{4}$",
       "description": "Reference year"
     },
-    "eea_tile": {
+    "tile_id": {
       "type": "string",
       "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
       "anyOf": [
@@ -56,7 +56,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "template": "{variable}_{reference_year}_{eea_tile}_{resolution}_{version}[.{extension}]",
+  "template": "{variable}_{reference_year}_{tile_id}_{resolution}_{version}[.{extension}]",
   "examples": [
     "IMD_2021_E042N018_010m_V100.tif"
   ]

--- a/src/parseo/schemas/copernicus/clms/hrl/imp_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/imp_filename_v0_0_0.json
@@ -4,15 +4,57 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS High Resolution Layer Imperviousness product filename (extension optional).",
   "fields": {
-    "variable": {"type": "string", "enum": ["IMD"], "description": "Product code"},
-    "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
-    "eea_tile": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA, LAEA reference grid tile identifier"},
-    "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+    "variable": {
+      "type": "string",
+      "enum": [
+        "IMD"
+      ],
+      "description": "Product code"
+    },
+    "reference_year": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "Reference year"
+    },
+    "eea_tile": {
+      "type": "string",
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
+    },
+    "resolution": {
+      "type": "string",
+      "pattern": "^(010m|020m|100m)$",
+      "description": "Spatial resolution"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{variable}_{reference_year}_{eea_tile}_{resolution}_{version}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hrl/nvlcc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/nvlcc_filename_v0_0_0.json
@@ -39,7 +39,7 @@
       "pattern": "^R\\d{2,3}m$",
       "description": "Spatial resolution"
     },
-    "eea_tile": {
+    "tile_id": {
       "type": "string",
       "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
       "anyOf": [
@@ -78,7 +78,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "template": "{prefix}_{theme}_{variable}_{temporal_coverage}_{resolution}_{eea_tile}_{epsg_code}_{version}_{release}[.{extension}]",
+  "template": "{prefix}_{theme}_{variable}_{temporal_coverage}_{resolution}_{tile_id}_{epsg_code}_{version}_{release}[.{extension}]",
   "examples": [
     "CLMS_HRLNVLCC_IMCCS_C2018-2021_R20m_E09N27_03035_V01_R01.tif",
     "CLMS_HRLNVLCC_IMD_S2021_R10m_E09N27_03035_V01_R01.tif",

--- a/src/parseo/schemas/copernicus/clms/hrl/nvlcc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/nvlcc_filename_v0_0_0.json
@@ -4,17 +4,24 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS High Resolution Layer Non-Vegetated Land Cover Characteristics product filename (extension optional).",
   "fields": {
     "prefix": {
       "type": "string",
-      "enum": ["CLMS"],
+      "enum": [
+        "CLMS"
+      ],
       "description": "Constant program prefix"
     },
     "theme": {
       "type": "string",
-      "enum": ["HRLNVLCC"],
+      "enum": [
+        "HRLNVLCC"
+      ],
       "description": "High Resolution Layer theme identifier"
     },
     "variable": {
@@ -34,8 +41,19 @@
     },
     "eea_tile": {
       "type": "string",
-      "pattern": "^[EW]\\d{2}[NS]\\d{2}$",
-      "description": "Tile identifier in the EEA 10m grid (easting/northing)"
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
     },
     "epsg_code": {
       "type": "string",
@@ -54,7 +72,9 @@
     },
     "extension": {
       "type": "string",
-      "enum": ["tif"],
+      "enum": [
+        "tif"
+      ],
       "description": "File extension without leading dot"
     }
   },

--- a/src/parseo/schemas/copernicus/clms/hrl/swf_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/swf_filename_v0_0_0.json
@@ -22,7 +22,7 @@
       "pattern": "^\\d{4}$",
       "description": "Reference year"
     },
-    "eea_tile": {
+    "tile_id": {
       "type": "string",
       "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
       "anyOf": [
@@ -56,7 +56,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "template": "{variable}_{reference_year}_{eea_tile}_{resolution}_{version}[.{extension}]",
+  "template": "{variable}_{reference_year}_{tile_id}_{resolution}_{version}[.{extension}]",
   "examples": [
     "SWF_2018_E042N018_010m_V100.tif"
   ]

--- a/src/parseo/schemas/copernicus/clms/hrl/swf_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/swf_filename_v0_0_0.json
@@ -4,15 +4,57 @@
   "schema_version": "0.0.0",
   "status": "deprecated",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS High Resolution Layer Small Woody Features product filename (extension optional).",
   "fields": {
-    "variable": {"type": "string", "enum": ["SWF"], "description": "Product code"},
-    "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
-    "eea_tile": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA, LAEA reference grid tile identifier"},
-    "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+    "variable": {
+      "type": "string",
+      "enum": [
+        "SWF"
+      ],
+      "description": "Product code"
+    },
+    "reference_year": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "Reference year"
+    },
+    "eea_tile": {
+      "type": "string",
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
+    },
+    "resolution": {
+      "type": "string",
+      "pattern": "^(010m|020m|100m)$",
+      "description": "Spatial resolution"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{variable}_{reference_year}_{eea_tile}_{resolution}_{version}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hrl/swf_filename_v0_0_1.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/swf_filename_v0_0_1.json
@@ -4,12 +4,17 @@
   "schema_version": "0.0.1",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS High Resolution Layer Small Woody Features product filename (extension optional).",
   "fields": {
     "variable": {
       "type": "string",
-      "enum": ["SWF"],
+      "enum": [
+        "SWF"
+      ],
       "description": "Product code"
     },
     "reference_year": {
@@ -24,8 +29,19 @@
     },
     "eea_tile": {
       "type": "string",
-      "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
-      "description": "EEA reference grid tile identifier"
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
     },
     "epsg_code": {
       "type": "string",
@@ -34,7 +50,9 @@
     },
     "extension": {
       "type": "string",
-      "enum": ["tif"],
+      "enum": [
+        "tif"
+      ],
       "description": "File extension without leading dot"
     }
   },

--- a/src/parseo/schemas/copernicus/clms/hrl/swf_filename_v0_0_1.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/swf_filename_v0_0_1.json
@@ -27,7 +27,7 @@
       "pattern": "^(?:005m|010m|020m|100m)$",
       "description": "Spatial resolution"
     },
-    "eea_tile": {
+    "tile_id": {
       "type": "string",
       "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
       "anyOf": [
@@ -56,7 +56,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "template": "{variable}_{reference_year}_{resolution}_{eea_tile}_{epsg_code}[.{extension}]",
+  "template": "{variable}_{reference_year}_{resolution}_{tile_id}_{epsg_code}[.{extension}]",
   "examples": [
     "SWF_2018_005m_E34N27_03035.tif",
     "SWF_2018_005m_E36N31_03035.tif"

--- a/src/parseo/schemas/copernicus/clms/hrl/tcd_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/tcd_filename_v0_0_0.json
@@ -4,15 +4,57 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS High Resolution Layer Tree Cover Density product filename (extension optional).",
   "fields": {
-    "variable": {"type": "string", "enum": ["TCD"], "description": "Product code"},
-    "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
-    "eea_tile": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA, LAEA reference grid tile identifier"},
-    "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+    "variable": {
+      "type": "string",
+      "enum": [
+        "TCD"
+      ],
+      "description": "Product code"
+    },
+    "reference_year": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "Reference year"
+    },
+    "eea_tile": {
+      "type": "string",
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
+    },
+    "resolution": {
+      "type": "string",
+      "pattern": "^(010m|020m|100m)$",
+      "description": "Spatial resolution"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{variable}_{reference_year}_{eea_tile}_{resolution}_{version}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hrl/tcd_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/tcd_filename_v0_0_0.json
@@ -22,7 +22,7 @@
       "pattern": "^\\d{4}$",
       "description": "Reference year"
     },
-    "eea_tile": {
+    "tile_id": {
       "type": "string",
       "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
       "anyOf": [
@@ -56,7 +56,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "template": "{variable}_{reference_year}_{eea_tile}_{resolution}_{version}[.{extension}]",
+  "template": "{variable}_{reference_year}_{tile_id}_{resolution}_{version}[.{extension}]",
   "examples": [
     "TCD_2018_E042N018_010m_V100.tif"
   ]

--- a/src/parseo/schemas/copernicus/clms/hrl/vlcc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/vlcc_filename_v0_0_0.json
@@ -39,7 +39,7 @@
       "pattern": "^R\\d{2,3}m$",
       "description": "Spatial resolution"
     },
-    "tile": {
+    "tile_id": {
       "type": "string",
       "description": "Regional LAEA grid tile, Sentinel-2 MGRS tile (2- or 3-digit coordinates), or two-letter geographic code",
       "anyOf": [
@@ -84,7 +84,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "template": "{programme}_{product}_{variable}_{temporal_coverage}_{resolution}_{tile}_{epsg_code}_{version}[_{release}][.{extension}]",
+  "template": "{programme}_{product}_{variable}_{temporal_coverage}_{resolution}_{tile_id}_{epsg_code}_{version}[_{release}][.{extension}]",
   "examples": [
     "CLMS_HRLVLCC_GRA_S2021_R10m_E27N48_03035_V01_R00.tif",
     "CLMS_HRLVLCC_CTY_S2021_R10m_E48N41_03035_V01_R00.tif",

--- a/src/parseo/schemas/copernicus/clms/hrl/vlcc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/vlcc_filename_v0_0_0.json
@@ -4,17 +4,24 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS High Resolution Layer Vegetated Land Cover Characteristics product filename (extension optional).",
   "fields": {
     "programme": {
       "type": "string",
-      "enum": ["CLMS"],
+      "enum": [
+        "CLMS"
+      ],
       "description": "Constant program prefix"
     },
     "product": {
       "type": "string",
-      "enum": ["HRLVLCC"],
+      "enum": [
+        "HRLVLCC"
+      ],
       "description": "High Resolution Layer theme identifier"
     },
     "variable": {
@@ -34,8 +41,24 @@
     },
     "tile": {
       "type": "string",
-      "pattern": "^(?:[EW]\\d{2}[NS]\\d{2}|[A-Z]{2})$",
-      "description": "Tile identifier in the EEA 10m grid (easting/northing) or two-letter geographic code"
+      "description": "Regional LAEA grid tile, Sentinel-2 MGRS tile (2- or 3-digit coordinates), or two-letter geographic code",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        },
+        {
+          "type": "string",
+          "pattern": "^[A-Z]{2}$",
+          "description": "Two-letter geographic code"
+        }
+      ]
     },
     "epsg_code": {
       "type": "string",
@@ -54,7 +77,10 @@
     },
     "extension": {
       "type": "string",
-      "enum": ["tif", "tiff"],
+      "enum": [
+        "tif",
+        "tiff"
+      ],
       "description": "File extension without leading dot"
     }
   },

--- a/src/parseo/schemas/copernicus/clms/hrl/waw_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/waw_filename_v0_0_0.json
@@ -22,7 +22,7 @@
       "pattern": "^\\d{4}$",
       "description": "Reference year"
     },
-    "eea_tile": {
+    "tile_id": {
       "type": "string",
       "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
       "anyOf": [
@@ -56,7 +56,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "template": "{variable}_{reference_year}_{eea_tile}_{resolution}_{version}[.{extension}]",
+  "template": "{variable}_{reference_year}_{tile_id}_{resolution}_{version}[.{extension}]",
   "examples": [
     "WAW_2018_E042N018_010m_V100.tif"
   ]

--- a/src/parseo/schemas/copernicus/clms/hrl/waw_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/waw_filename_v0_0_0.json
@@ -4,15 +4,57 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS High Resolution Layer Water & Wetness product filename (extension optional).",
   "fields": {
-    "variable": {"type": "string", "enum": ["WAW"], "description": "Product code"},
-    "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
-    "eea_tile": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA, LAEA reference grid tile identifier"},
-    "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+    "variable": {
+      "type": "string",
+      "enum": [
+        "WAW"
+      ],
+      "description": "Product code"
+    },
+    "reference_year": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "Reference year"
+    },
+    "eea_tile": {
+      "type": "string",
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
+    },
+    "resolution": {
+      "type": "string",
+      "pattern": "^(010m|020m|100m)$",
+      "description": "Spatial resolution"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{variable}_{reference_year}_{eea_tile}_{resolution}_{version}[.{extension}]",
   "examples": [

--- a/src/parseo/template.py
+++ b/src/parseo/template.py
@@ -16,6 +16,15 @@ def _field_regex(spec: Union[Dict, None]) -> str:
         return ".+"
     if "enum" in spec:
         return "(?:" + "|".join(re.escape(v) for v in spec["enum"]) + ")"
+    if "anyOf" in spec:
+        options = [
+            _field_regex(option)
+            for option in spec["anyOf"]
+            if option is not None
+        ]
+        if not options:
+            raise KeyError("Field spec 'anyOf' must contain at least one option")
+        return "(?:" + "|".join(options) + ")"
     pattern = spec.get("pattern")
     if pattern is None:
         raise KeyError("Field spec missing 'pattern' or 'enum'")

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -20,7 +20,7 @@ def test_assemble_missing_field_template_schema():
         "project": "WSI",
         "product": "FSC",
         "pixel_spacing": "020m",
-        "mgrs_tile": "T32TNS",
+        "tile_id": "T32TNS",
         "sensing_datetime": "20211018T103021",
         # "platform" is intentionally omitted
         "version": "V100",
@@ -94,7 +94,7 @@ def test_assemble_clms_hrl_imperviousness():
     fields = {
         "variable": "IMD",
         "reference_year": "2021",
-        "eea_tile": "E042N018",
+        "tile_id": "E042N018",
         "resolution": "010m",
         "version": "V100",
         "extension": "tif",
@@ -135,7 +135,7 @@ def test_assemble_clms_clcplus_with_canonical_type():
         "type": "raster",
         "season": "S2023",
         "resolution": "R10m",
-        "eea_tile": "E48N37",
+        "tile_id": "E48N37",
         "epsg_code": "03035",
         "version": "V01",
         "revision": "R00",

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -188,3 +188,43 @@ def test_assemble_landsat_from_stac_fields():
     assembled = assemble(fields, schema_path=schema)
     assert assembled == "LC08_L1TP_190026_20200101_20200114_02_T1.tar"
 
+
+
+
+def test_assemble_clms_hr_vpp_from_mgrs_tile():
+    fields = {
+        "product": "VPP",
+        "reference_year": "2017",
+        "platform": "Sentinel-2",
+        "constellation": "Sentinel-2",
+        "instruments": ["MSI"],
+        "mgrs_tile": "T32TPR",
+        "resolution": "010m",
+        "version": "V101",
+        "season": "s1",
+        "variable": "AMPL",
+        "extension": "tif",
+    }
+
+    name = assemble(fields, family="VPP")
+    assert name == "VPP_2017_S2_T32TPR-010m_V101_s1_AMPL.tif"
+
+
+def test_assemble_clms_hr_vpp_from_eea_tile():
+    fields = {
+        "product": "VPP",
+        "reference_year": "2017",
+        "platform": "Sentinel-2",
+        "constellation": "Sentinel-2",
+        "instruments": ["MSI"],
+        "eea_tile": "E042N018",
+        "epsg_code": "03035",
+        "resolution": "010m",
+        "version": "V101",
+        "season": "s1",
+        "variable": "EOSD",
+        "extension": "tif",
+    }
+
+    name = assemble(fields, family="VPP")
+    assert name == "VPP_2017_S2_E042N018-03035-010m_V101_s1_EOSD.tif"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -353,3 +353,28 @@ def test_parse_sentinel2_epsg_lookup():
     assert result.match_family == "S2"
     assert result.fields["mgrs_tile"] == "T03VUL"
     assert result.fields["epsg_code"] == "32603"
+
+
+
+
+def test_parse_clms_hr_vpp_mgrs_tile():
+    name = "VPP_2017_S2_T32TPR-010m_V101_s1_AMPL.tif"
+    result = parse_auto(name)
+
+    assert result.valid
+    assert result.match_family == "VPP"
+    assert result.fields["tile"] == "T32TPR"
+    assert result.fields["mgrs_tile"] == "T32TPR"
+    assert "eea_tile" not in result.fields
+
+
+def test_parse_clms_hr_vpp_eea_tile():
+    name = "VPP_2017_S2_E042N018-03035-010m_V101_s1_EOSD.tif"
+    result = parse_auto(name)
+
+    assert result.valid
+    assert result.match_family == "VPP"
+    assert result.fields["tile"] == "E042N018"
+    assert result.fields["eea_tile"] == "E042N018"
+    assert result.fields["epsg_code"] == "03035"
+    assert "mgrs_tile" not in result.fields

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -201,18 +201,18 @@ def test_parse_clms_hrl_nvlcc():
 
     assert result.valid
     assert result.match_family == "NVLCC"
-    assert result.fields == {
-        "prefix": "CLMS",
-        "theme": "HRLNVLCC",
-        "variable": "IMD",
-        "temporal_coverage": "S2021",
-        "resolution": "R10m",
-        "eea_tile": "E09N27",
-        "epsg_code": "03035",
-        "version": "V01",
-        "release": "R01",
-        "extension": "tif",
-    }
+    assert result.fields["prefix"] == "CLMS"
+    assert result.fields["theme"] == "HRLNVLCC"
+    assert result.fields["variable"] == "IMD"
+    assert result.fields["temporal_coverage"] == "S2021"
+    assert result.fields["resolution"] == "R10m"
+    assert result.fields["tile_id"] == "E09N27"
+    assert result.fields["tile"] == "E09N27"
+    assert result.fields["eea_tile"] == "E09N27"
+    assert result.fields["epsg_code"] == "03035"
+    assert result.fields["version"] == "V01"
+    assert result.fields["release"] == "R01"
+    assert result.fields["extension"] == "tif"
 
 
 def test_parse_clms_hrl_nvlcc_unpadded_epsg():
@@ -230,14 +230,14 @@ def test_parse_clms_hrl_small_woody_features():
 
     assert result.valid
     assert result.match_family == "SMALL-WOODY-FEATURES"
-    assert result.fields == {
-        "variable": "SWF",
-        "reference_year": "2018",
-        "resolution": "005m",
-        "eea_tile": "E34N27",
-        "epsg_code": "03035",
-        "extension": "tif",
-    }
+    assert result.fields["variable"] == "SWF"
+    assert result.fields["reference_year"] == "2018"
+    assert result.fields["resolution"] == "005m"
+    assert result.fields["tile_id"] == "E34N27"
+    assert result.fields["tile"] == "E34N27"
+    assert result.fields["eea_tile"] == "E34N27"
+    assert result.fields["epsg_code"] == "03035"
+    assert result.fields["extension"] == "tif"
 
 
 def test_parse_clms_hrl_imperviousness():
@@ -246,14 +246,14 @@ def test_parse_clms_hrl_imperviousness():
 
     assert result.valid
     assert result.match_family == "IMPERVIOUSNESS"
-    assert result.fields == {
-        "variable": "IMD",
-        "reference_year": "2021",
-        "eea_tile": "E042N018",
-        "resolution": "010m",
-        "version": "V100",
-        "extension": "tif",
-    }
+    assert result.fields["variable"] == "IMD"
+    assert result.fields["reference_year"] == "2021"
+    assert result.fields["tile_id"] == "E042N018"
+    assert result.fields["tile"] == "E042N018"
+    assert result.fields["eea_tile"] == "E042N018"
+    assert result.fields["resolution"] == "010m"
+    assert result.fields["version"] == "V100"
+    assert result.fields["extension"] == "tif"
 
 def test_parse_clms_egms_l3_velocity_grid():
     name = "EGMS_L3_E28N49_100km_U_2018_2022_1.tiff"
@@ -263,6 +263,7 @@ def test_parse_clms_egms_l3_velocity_grid():
     assert result.match_family == "EGMS-L3"
     assert result.fields["product"] == "EGMS"
     assert result.fields["level"] == "L3"
+    assert result.fields["tile_id"] == "E28N49"
     assert result.fields["tile"] == "E28N49"
     assert result.fields["tile_size"] == "100km"
     assert result.fields["component"] == "U"
@@ -363,6 +364,7 @@ def test_parse_clms_hr_vpp_mgrs_tile():
 
     assert result.valid
     assert result.match_family == "VPP"
+    assert result.fields["tile_id"] == "T32TPR"
     assert result.fields["tile"] == "T32TPR"
     assert result.fields["mgrs_tile"] == "T32TPR"
     assert "eea_tile" not in result.fields
@@ -374,6 +376,7 @@ def test_parse_clms_hr_vpp_eea_tile():
 
     assert result.valid
     assert result.match_family == "VPP"
+    assert result.fields["tile_id"] == "E042N018"
     assert result.fields["tile"] == "E042N018"
     assert result.fields["eea_tile"] == "E042N018"
     assert result.fields["epsg_code"] == "03035"


### PR DESCRIPTION
## Summary
- replace CLMS tile field regexes with anyOf clauses so LAEA and MGRS identifiers have distinct validation patterns (retaining legacy VLCC two-letter codes)
- teach the template compiler to collapse anyOf options into alternations when generating filename regexes

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2985d47ec832785c252c26e656da7