### PR TITLE
Support oneOf tile identifiers in CLMS schemas

### DIFF
--- a/src/parseo/schemas/copernicus/clms/hr-wsi/icd/icd_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/icd/icd_filename_v0_0_0.json
@@ -4,18 +4,85 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": [
+    "raster",
+    "eo"
+  ],
   "description": "CLMS HR-WSI Ice Cover Duration product filename (extension optional).",
   "fields": {
-    "prefix": {"type": "string", "enum": ["CLMS_WSI"], "description": "Constant prefix"},
-    "product": {"type": "string", "enum": ["ICD"], "description": "Product code"},
-    "pixel_spacing": {"type": "string", "enum": ["020m", "100m"], "description": "Pixel spacing"},
-    "tile_id": {"type": "string", "pattern": "^(?:T\\d{2}[C-HJ-NP-X][A-Z]{2}|E\\d{2}N\\d{2})$", "description": "Tile identifier"},
-    "period_start": {"type": "string", "pattern": "^\\d{8}P1Y$", "description": "Aggregation period start"},
-    "combination": {"type": "string", "enum": ["COMB"], "description": "Combination method"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "file_id": {"type": "string", "enum": ["ICD", "NOBS1", "NOBS2", "ICD-QA", "MTD"], "description": "File identifier"},
-    "extension": {"type": "string", "enum": ["tif", "xml"], "description": "File extension without leading dot"}
+    "prefix": {
+      "type": "string",
+      "enum": [
+        "CLMS_WSI"
+      ],
+      "description": "Constant prefix"
+    },
+    "product": {
+      "type": "string",
+      "enum": [
+        "ICD"
+      ],
+      "description": "Product code"
+    },
+    "pixel_spacing": {
+      "type": "string",
+      "enum": [
+        "020m",
+        "100m"
+      ],
+      "description": "Pixel spacing"
+    },
+    "tile_id": {
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
+    },
+    "period_start": {
+      "type": "string",
+      "pattern": "^\\d{8}P1Y$",
+      "description": "Aggregation period start"
+    },
+    "combination": {
+      "type": "string",
+      "enum": [
+        "COMB"
+      ],
+      "description": "Combination method"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "file_id": {
+      "type": "string",
+      "enum": [
+        "ICD",
+        "NOBS1",
+        "NOBS2",
+        "ICD-QA",
+        "MTD"
+      ],
+      "description": "File identifier"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif",
+        "xml"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{prefix}_{product}_{pixel_spacing}_{tile_id}_{period_start}_{combination}_{version}_{file_id}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/sp_comb/sp_comb_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/sp_comb/sp_comb_filename_v0_0_0.json
@@ -4,18 +4,90 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": [
+    "raster",
+    "eo"
+  ],
   "description": "CLMS HR-WSI Snow Products combination filename (extension optional).",
   "fields": {
-    "prefix": {"type": "string", "enum": ["CLMS_WSI"], "description": "Constant prefix"},
-    "product": {"type": "string", "enum": ["SP"], "description": "Product code"},
-    "pixel_spacing": {"type": "string", "enum": ["060m", "100m"], "description": "Pixel spacing"},
-    "tile_id": {"type": "string", "pattern": "^(?:T\\d{2}[C-HJ-NP-X][A-Z]{2}|E\\d{2}N\\d{2})$", "description": "Tile identifier"},
-    "period_start": {"type": "string", "pattern": "^\\d{8}P1Y$", "description": "Aggregation period start"},
-    "combination": {"type": "string", "enum": ["COMB"], "description": "Combination method"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "file_id": {"type": "string", "enum": ["SCD", "SCO", "SCM", "NCSO", "NWSO", "QAFLAGS", "SCD-QA", "SCO-QA", "SCM-QA", "MTD"], "description": "File identifier"},
-    "extension": {"type": "string", "enum": ["tif", "xml"], "description": "File extension without leading dot"}
+    "prefix": {
+      "type": "string",
+      "enum": [
+        "CLMS_WSI"
+      ],
+      "description": "Constant prefix"
+    },
+    "product": {
+      "type": "string",
+      "enum": [
+        "SP"
+      ],
+      "description": "Product code"
+    },
+    "pixel_spacing": {
+      "type": "string",
+      "enum": [
+        "060m",
+        "100m"
+      ],
+      "description": "Pixel spacing"
+    },
+    "tile_id": {
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
+    },
+    "period_start": {
+      "type": "string",
+      "pattern": "^\\d{8}P1Y$",
+      "description": "Aggregation period start"
+    },
+    "combination": {
+      "type": "string",
+      "enum": [
+        "COMB"
+      ],
+      "description": "Combination method"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "file_id": {
+      "type": "string",
+      "enum": [
+        "SCD",
+        "SCO",
+        "SCM",
+        "NCSO",
+        "NWSO",
+        "QAFLAGS",
+        "SCD-QA",
+        "SCO-QA",
+        "SCM-QA",
+        "MTD"
+      ],
+      "description": "File identifier"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif",
+        "xml"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{prefix}_{product}_{pixel_spacing}_{tile_id}_{period_start}_{combination}_{version}_{file_id}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/sp_s2/sp_s2_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/sp_s2/sp_s2_filename_v0_0_0.json
@@ -4,18 +4,89 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": [
+    "raster",
+    "eo"
+  ],
   "description": "CLMS HR-WSI Snow Products Sentinel-2 source filename (extension optional).",
   "fields": {
-    "prefix": {"type": "string", "enum": ["CLMS_WSI"], "description": "Constant prefix"},
-    "product": {"type": "string", "enum": ["SP"], "description": "Product code"},
-    "pixel_spacing": {"type": "string", "enum": ["020m", "100m"], "description": "Pixel spacing"},
-    "tile_id": {"type": "string", "pattern": "^(?:T\\d{2}[C-HJ-NP-X][A-Z]{2}|E\\d{2}N\\d{2})$", "description": "Tile identifier"},
-    "period_start": {"type": "string", "pattern": "^\\d{8}P1Y$", "description": "Aggregation period start"},
-    "source": {"type": "string", "enum": ["S2"], "description": "Source mission"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "file_id": {"type": "string", "enum": ["SCD", "SCO", "SCM", "NOBS", "QAFLAGS", "SCD-QA", "SCO-QA", "SCM-QA", "MTD"], "description": "File identifier"},
-    "extension": {"type": "string", "enum": ["tif", "xml"], "description": "File extension without leading dot"}
+    "prefix": {
+      "type": "string",
+      "enum": [
+        "CLMS_WSI"
+      ],
+      "description": "Constant prefix"
+    },
+    "product": {
+      "type": "string",
+      "enum": [
+        "SP"
+      ],
+      "description": "Product code"
+    },
+    "pixel_spacing": {
+      "type": "string",
+      "enum": [
+        "020m",
+        "100m"
+      ],
+      "description": "Pixel spacing"
+    },
+    "tile_id": {
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
+    },
+    "period_start": {
+      "type": "string",
+      "pattern": "^\\d{8}P1Y$",
+      "description": "Aggregation period start"
+    },
+    "source": {
+      "type": "string",
+      "enum": [
+        "S2"
+      ],
+      "description": "Source mission"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "file_id": {
+      "type": "string",
+      "enum": [
+        "SCD",
+        "SCO",
+        "SCM",
+        "NOBS",
+        "QAFLAGS",
+        "SCD-QA",
+        "SCO-QA",
+        "SCM-QA",
+        "MTD"
+      ],
+      "description": "File identifier"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif",
+        "xml"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{prefix}_{product}_{pixel_spacing}_{tile_id}_{period_start}_{source}_{version}_{file_id}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hrl/forest-type/forest-type_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/forest-type/forest-type_filename_v0_0_0.json
@@ -9,7 +9,21 @@
   "fields": {
     "product": {"type": "string", "enum": ["FTY"], "description": "Product code"},
     "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
-    "tile_id": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA reference grid tile identifier"},
+    "tile_id": {
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
+    },
     "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
     "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
     "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}

--- a/src/parseo/schemas/copernicus/clms/hrl/grassland/grassland_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/grassland/grassland_filename_v0_0_0.json
@@ -4,15 +4,56 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": [
+    "raster",
+    "eo"
+  ],
   "description": "CLMS High Resolution Layer Grassland product filename (extension optional).",
   "fields": {
-    "product": {"type": "string", "enum": ["GRA"], "description": "Product code"},
-    "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
-    "tile_id": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA reference grid tile identifier"},
-    "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+    "product": {
+      "type": "string",
+      "enum": [
+        "GRA"
+      ],
+      "description": "Product code"
+    },
+    "reference_year": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "Reference year"
+    },
+    "tile_id": {
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
+    },
+    "resolution": {
+      "type": "string",
+      "pattern": "^(010m|020m|100m)$",
+      "description": "Spatial resolution"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{product}_{reference_year}_{tile_id}_{resolution}_{version}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hrl/imperviousness/imperviousness_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/imperviousness/imperviousness_filename_v0_0_0.json
@@ -4,15 +4,56 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": [
+    "raster",
+    "eo"
+  ],
   "description": "CLMS High Resolution Layer Imperviousness product filename (extension optional).",
   "fields": {
-    "product": {"type": "string", "enum": ["IMD"], "description": "Product code"},
-    "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
-    "tile_id": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA reference grid tile identifier"},
-    "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+    "product": {
+      "type": "string",
+      "enum": [
+        "IMD"
+      ],
+      "description": "Product code"
+    },
+    "reference_year": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "Reference year"
+    },
+    "tile_id": {
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
+    },
+    "resolution": {
+      "type": "string",
+      "pattern": "^(010m|020m|100m)$",
+      "description": "Spatial resolution"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{product}_{reference_year}_{tile_id}_{resolution}_{version}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hrl/small-woody-features/small-woody-features_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/small-woody-features/small-woody-features_filename_v0_0_0.json
@@ -4,15 +4,56 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": [
+    "raster",
+    "eo"
+  ],
   "description": "CLMS High Resolution Layer Small Woody Features product filename (extension optional).",
   "fields": {
-    "product": {"type": "string", "enum": ["SWF"], "description": "Product code"},
-    "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
-    "tile_id": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA reference grid tile identifier"},
-    "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+    "product": {
+      "type": "string",
+      "enum": [
+        "SWF"
+      ],
+      "description": "Product code"
+    },
+    "reference_year": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "Reference year"
+    },
+    "tile_id": {
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
+    },
+    "resolution": {
+      "type": "string",
+      "pattern": "^(010m|020m|100m)$",
+      "description": "Spatial resolution"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{product}_{reference_year}_{tile_id}_{resolution}_{version}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hrl/tree-cover-density/tree-cover-density_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/tree-cover-density/tree-cover-density_filename_v0_0_0.json
@@ -4,15 +4,56 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": [
+    "raster",
+    "eo"
+  ],
   "description": "CLMS High Resolution Layer Tree Cover Density product filename (extension optional).",
   "fields": {
-    "product": {"type": "string", "enum": ["TCD"], "description": "Product code"},
-    "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
-    "tile_id": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA reference grid tile identifier"},
-    "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+    "product": {
+      "type": "string",
+      "enum": [
+        "TCD"
+      ],
+      "description": "Product code"
+    },
+    "reference_year": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "Reference year"
+    },
+    "tile_id": {
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
+    },
+    "resolution": {
+      "type": "string",
+      "pattern": "^(010m|020m|100m)$",
+      "description": "Spatial resolution"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{product}_{reference_year}_{tile_id}_{resolution}_{version}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hrl/water-wetness/water-wetness_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/water-wetness/water-wetness_filename_v0_0_0.json
@@ -4,15 +4,56 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["raster", "eo"],
+  "stac_extensions": [
+    "raster",
+    "eo"
+  ],
   "description": "CLMS High Resolution Layer Water & Wetness product filename (extension optional).",
   "fields": {
-    "product": {"type": "string", "enum": ["WAW"], "description": "Product code"},
-    "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
-    "tile_id": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA reference grid tile identifier"},
-    "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+    "product": {
+      "type": "string",
+      "enum": [
+        "WAW"
+      ],
+      "description": "Product code"
+    },
+    "reference_year": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "Reference year"
+    },
+    "tile_id": {
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
+    },
+    "resolution": {
+      "type": "string",
+      "pattern": "^(010m|020m|100m)$",
+      "description": "Spatial resolution"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{product}_{reference_year}_{tile_id}_{resolution}_{version}[.{extension}]",
   "examples": [

--- a/src/parseo/template.py
+++ b/src/parseo/template.py
@@ -16,6 +16,12 @@ def _field_regex(spec: Union[Dict, None]) -> str:
         return ".+"
     if "enum" in spec:
         return "(?:" + "|".join(re.escape(v) for v in spec["enum"]) + ")"
+    for key in ("oneOf", "anyOf"):
+        if key in spec:
+            options = spec[key]
+            if not options:
+                raise KeyError(f"Field spec '{key}' is empty")
+            return "(?:" + "|".join(_field_regex(option) for option in options) + ")"
     pattern = spec.get("pattern")
     if pattern is None:
         raise KeyError("Field spec missing 'pattern' or 'enum'")


### PR DESCRIPTION
## Summary
- allow CLMS HRL filename schemas to express LAEA or MGRS tile identifiers via JSON Schema `oneOf`
- update HR-WSI schemas to support both tile formats and extend examples accordingly
- teach the template compiler to expand `oneOf`/`anyOf` definitions when generating filename patterns

## Testing
- ruff check .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e2cfb5e6088327a17ed9ddd23dc8a0