### PR TITLE
Add schema for Copernicus CLMS N2K filenames

### DIFF
--- a/src/parseo/schemas/copernicus/clms/n2k/n2k_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/n2k/n2k_filename_v1_0_0.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "schema_id": "copernicus:clms:n2k",
+  "schema_version": "1.0.0",
+  "status": "current",
+  "stac_version": "1.1.0",
+  "stac_extensions": [],
+  "description": "Copernicus CLMS Natura 2000 (N2K) status and change layers filename (extension optional).",
+  "fields": {
+    "theme": {
+      "type": "string",
+      "enum": ["N2K", "N2K_Change"],
+      "description": "Dataset theme"
+    },
+    "reference": {
+      "type": "string",
+      "pattern": "^(?:2006|2012|2018|2006-2012|2012-2018)$",
+      "description": "Reference year or period"
+    },
+    "epsg_code": {
+      "type": "string",
+      "pattern": "^EPSG\\d{4,5}$",
+      "description": "EPSG code"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d+(?:_\\d+)*$",
+      "description": "Product version"
+    },
+    "extension": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9]+$",
+      "description": "File extension without leading dot"
+    }
+  },
+  "template": "{theme}_{reference}_{epsg_code}_{version}[.{extension}]",
+  "examples": [
+    "N2K_2018_EPSG3035_V1_0.gpkg",
+    "N2K_Change_2012-2018_EPSG3035_V2_0.zip"
+  ]
+}

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -104,6 +104,19 @@ def test_assemble_clms_hrl_imperviousness():
     assert name == "IMD_2021_E042N018_010m_V100.tif"
 
 
+def test_assemble_clms_n2k():
+    fields = {
+        "theme": "N2K",
+        "reference": "2018",
+        "epsg_code": "EPSG3035",
+        "version": "V1_0",
+        "extension": "gpkg",
+    }
+
+    name = assemble(fields, family="N2K")
+    assert name == "N2K_2018_EPSG3035_V1_0.gpkg"
+
+
 def test_assemble_clms_urban_atlas_with_canonical_type():
     fields = {
         "programme": "CLMS",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -378,3 +378,18 @@ def test_parse_clms_hr_vpp_eea_tile():
     assert result.fields["eea_tile"] == "E45N28"
     assert result.fields["epsg_code"] == "03035"
     assert "mgrs_tile" not in result.fields
+
+
+def test_parse_clms_n2k_change():
+    name = "N2K_Change_2012-2018_EPSG3035_V2_0.zip"
+    result = parse_auto(name)
+
+    assert result.valid
+    assert result.match_family == "N2K"
+    assert result.fields == {
+        "theme": "N2K_Change",
+        "reference": "2012-2018",
+        "epsg_code": "EPSG3035",
+        "version": "V2_0",
+        "extension": "zip",
+    }


### PR DESCRIPTION
## Summary
- add the Copernicus CLMS Natura 2000 filename schema following the latest template
- cover assembler and parser behaviour for N2K names with dedicated tests

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2d19dca7083278a28f8e83b7d9d5b