### PR TITLE
Extend oneOf tile identifier support to HR-VPP schemas

### DIFF
--- a/src/parseo/schemas/copernicus/clms/hr-vpp/st_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/st_filename_v0_0_0.json
@@ -11,9 +11,19 @@
     "timestamp": {"type": "string", "pattern": "^\\d{8}T\\d{6}$", "description": "Acquisition timestamp (YYYYMMDDTHHMMSS)"},
     "sensor": {"type": "string", "enum": ["S2"], "description": "Sensor platform"},
     "eea_tile": {
-      "type": "string",
-      "pattern": "^([EW]\\d{2,3}[NS]\\d{2,3}|T\\d{2}[C-HJ-NP-X][A-Z]{2})$",
-      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)"
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
     },
     "epsg_code": {
       "type": "string",

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/vpp_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/vpp_filename_v0_0_0.json
@@ -33,9 +33,19 @@
       }
     },
     "tile": {
-      "type": "string",
-      "pattern": "^(?:T\\d{2}[C-HJ-NP-X][A-Z]{2}|[EW]\\d{2,3}[NS]\\d{2,3})$",
-      "description": "Sentinel-2 MGRS tile or EEA LAEA reference grid cell identifier (2- or 3-digit coordinates)"
+      "description": "Sentinel-2 MGRS tile or EEA LAEA reference grid cell identifier (2- or 3-digit coordinates)",
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        },
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "EEA LAEA reference grid cell identifier (2- or 3-digit coordinates)"
+        }
+      ]
     },
     "epsg_code": {
       "type": "string",

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/icd_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/icd_filename_v0_0_0.json
@@ -19,7 +19,21 @@
     },
     "product": {"type": "string", "enum": ["ICD"], "description": "Product code"},
     "pixel_spacing": {"type": "string", "enum": ["020m", "100m"], "description": "Pixel spacing"},
-    "tile_id": {"type": "string", "pattern": "^(?:T\\d{2}[C-HJ-NP-X][A-Z]{2}|E\\d{2}N\\d{2})$", "description": "Tile identifier"},
+    "tile_id": {
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
+    },
     "period_start": {"type": "string", "pattern": "^\\d{8}P1Y$", "description": "Aggregation period start"},
     "combination": {"type": "string", "enum": ["COMB"], "description": "Combination method"},
     "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/sp_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/sp_filename_v0_0_0.json
@@ -31,9 +31,19 @@
       "description": "Pixel spacing"
     },
     "tile_id": {
-      "type": "string",
-      "pattern": "^(?:T\\d{2}[C-HJ-NP-X][A-Z]{2}|E\\d{2}N\\d{2})$",
-      "description": "Tile identifier"
+      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "type": "string",
+          "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+          "description": "Sentinel-2 MGRS tile identifier"
+        }
+      ]
     },
     "period_start": {
       "type": "string",

--- a/src/parseo/template.py
+++ b/src/parseo/template.py
@@ -16,6 +16,15 @@ def _field_regex(spec: Union[Dict, None]) -> str:
         return ".+"
     if "enum" in spec:
         return "(?:" + "|".join(re.escape(v) for v in spec["enum"]) + ")"
+    if "oneOf" in spec:
+        options = [
+            _field_regex(option)
+            for option in spec["oneOf"]
+            if option is not None
+        ]
+        if not options:
+            return ".+"
+        return "(?:" + "|".join(f"(?:{option})" for option in options) + ")"
     pattern = spec.get("pattern")
     if pattern is None:
         raise KeyError("Field spec missing 'pattern' or 'enum'")


### PR DESCRIPTION
## Summary
- update HR-WSI ICD and SP filename schemas to allow either LAEA or MGRS tile identifiers using oneOf constraints
- enhance template compilation to support schema fields defined with oneOf options
- extend HR-VPP ST and VPP filename schemas to support both LAEA and MGRS tile identifiers via oneOf validation

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2d0d659d48327b4cf6cf71a1222ac