### PR TITLE
Replace remaining eea tile references with tile_id

### DIFF
--- a/src/parseo/_field_mappings.py
+++ b/src/parseo/_field_mappings.py
@@ -79,7 +79,7 @@ def get_schema_field_mappings(schema: Mapping[str, Any]) -> Dict[str, FieldMappi
 
 def _augment_with_tile_variants(fields: Dict[str, Any]) -> Dict[str, Any]:
     enriched = dict(fields)
-    for candidate in ("tile", "tile_id", "mgrs_tile", "eea_tile"):
+    for candidate in ("tile", "tile_id", "mgrs_tile"):
         value = enriched.get(candidate)
         if not isinstance(value, str):
             continue
@@ -93,8 +93,11 @@ def _augment_with_tile_variants(fields: Dict[str, Any]) -> Dict[str, Any]:
 
         if system is TileSystem.MGRS and "mgrs_tile" not in enriched:
             enriched["mgrs_tile"] = normalized
-        if system is TileSystem.EEA and "eea_tile" not in enriched:
-            enriched["eea_tile"] = normalized
+        if system is TileSystem.EEA:
+            if "tile_id" not in enriched:
+                enriched["tile_id"] = normalized
+            if "epsg_code" not in enriched:
+                enriched["epsg_code"] = "03035"
 
     return enriched
 
@@ -106,14 +109,14 @@ def _backfill_tile_tokens(
     specs = schema.get("fields", {})
 
     if "tile" in specs and "tile" not in translated:
-        for key in ("mgrs_tile", "eea_tile", "tile_id"):
+        for key in ("mgrs_tile", "tile_id"):
             value = translated.get(key)
             if isinstance(value, str) and value:
                 translated["tile"] = normalize_tile(value)
                 break
 
     if "tile_id" in specs and "tile_id" not in translated:
-        for key in ("mgrs_tile", "eea_tile", "tile"):
+        for key in ("mgrs_tile", "tile"):
             value = translated.get(key)
             if isinstance(value, str) and value:
                 translated["tile_id"] = normalize_tile(value)

--- a/src/parseo/parser.py
+++ b/src/parseo/parser.py
@@ -94,8 +94,8 @@ def _match_filename(name: str, schema: Dict) -> Optional[re.Match]:
 def _normalize_epsg_fields(fields: Dict[str, Any]) -> Dict[str, Any]:
     """Normalize EPSG-related fields to consistently use 5-digit codes."""
 
-    normalized = dict(fields)
-    for key, value in fields.items():
+    normalized = {k: v for k, v in fields.items() if v is not None}
+    for key, value in list(normalized.items()):
         if not isinstance(key, str):
             continue
         key_lower = key.lower()

--- a/src/parseo/schemas/copernicus/clms/clcplus/ras/clcplus_filename_v0_0_1.json
+++ b/src/parseo/schemas/copernicus/clms/clcplus/ras/clcplus_filename_v0_0_1.json
@@ -37,7 +37,7 @@
       "pattern": "^R\\d{2}m$",
       "description": "Spatial resolution expressed with leading 'R' and units"
     },
-    "eea_tile": {
+    "tile_id": {
       "type": "string",
       "pattern": "^[EW]\\d{2}[NS]\\d{2}$",
       "description": "Tile identifier in the EEA 10m grid (easting/northing)"
@@ -63,7 +63,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "template": "{programme}_{product}_{type}_{season}_{resolution}_{eea_tile}_{epsg_code}_{version}_{revision}[.{extension}]",
+  "template": "{programme}_{product}_{type}_{season}_{resolution}_{tile_id}_{epsg_code}_{version}_{revision}[.{extension}]",
   "examples": [
     "CLMS_CLCPLUS_RAS_S2023_R10m_E48N37_03035_V01_R00.tif"
   ]

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/st_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/st_filename_v0_0_0.json
@@ -39,7 +39,7 @@
     },
     "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
   },
-  "template": "{product}_{timestamp}_{sensor}_{tile_id}[-03035]-{resolution}_{version}_{variable}[.{extension}]",
+  "template": "{product}_{timestamp}_{sensor}_{tile_id}[-{epsg_code}]-{resolution}_{version}_{variable}[.{extension}]",
   "examples": [
     "ST_20170101T000000_S2_E10N25-03035-010m_V101_PPI.tif",
     "ST_20170101T000000_S2_E10N25-03035-010m_V101_QFLAG.tif",

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/vpp_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/vpp_filename_v0_0_0.json
@@ -47,6 +47,11 @@
         }
       ]
     },
+    "epsg_code": {
+      "type": "string",
+      "pattern": "^\\d{5}$",
+      "description": "EPSG code of the product grid (zero-padded)"
+    },
     "resolution": {
       "type": "string",
       "pattern": "^\\d{3}m$",
@@ -88,7 +93,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "template": "{product}_{reference_year}_{sensor}_{tile}[-03035]-{resolution}_{version}_{season}_{variable}[.{extension}]",
+  "template": "{product}_{reference_year}_{sensor}_{tile}[-{epsg_code}]-{resolution}_{version}_{season}_{variable}[.{extension}]",
   "examples": [
     "VPP_2017_S2_T32TPR-010m_V101_s1_AMPL.tif",
     "VPP_2017_S2_E45N28-03035-010m_V101_s1_EOSD.tif",

--- a/src/parseo/schemas/copernicus/clms/hrl/fty_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/fty_filename_v0_0_0.json
@@ -9,12 +9,12 @@
   "fields": {
     "variable": {"type": "string", "enum": ["FTY"], "description": "Product code"},
     "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
-    "eea_tile": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA, LAEA reference grid tile identifier"},
+    "tile_id": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA, LAEA reference grid tile identifier"},
     "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
     "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
     "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
   },
-  "template": "{variable}_{reference_year}_{eea_tile}_{resolution}_{version}[.{extension}]",
+  "template": "{variable}_{reference_year}_{tile_id}_{resolution}_{version}[.{extension}]",
   "examples": [
     "FTY_2018_E042N018_010m_V100.tif"
   ]

--- a/src/parseo/schemas/copernicus/clms/hrl/gra_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/gra_filename_v0_0_0.json
@@ -9,12 +9,12 @@
   "fields": {
     "variable": {"type": "string", "enum": ["GRA"], "description": "Product code"},
     "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
-    "eea_tile": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA, LAEA reference grid tile identifier"},
+    "tile_id": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA, LAEA reference grid tile identifier"},
     "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
     "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
     "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
   },
-  "template": "{variable}_{reference_year}_{eea_tile}_{resolution}_{version}[.{extension}]",
+  "template": "{variable}_{reference_year}_{tile_id}_{resolution}_{version}[.{extension}]",
   "examples": [
     "GRA_2018_E042N018_010m_V100.tif"
   ]

--- a/src/parseo/schemas/copernicus/clms/hrl/ibu_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/ibu_filename_v0_0_0.json
@@ -10,12 +10,12 @@
     "variable": {"type": "string", "enum": ["IBU"], "description": "Product code"},
     "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
     "resolution": {"type": "string", "pattern": "^\\d{3}m$", "description": "Spatial resolution in metres with leading zeros"},
-    "eea_tile": {"type": "string", "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$", "description": "EEA reference grid tile identifier"},
+    "tile_id": {"type": "string", "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$", "description": "EEA reference grid tile identifier"},
     "epsg_code": {"type": "string", "pattern": "^\\d{5}$", "description": "EPSG code of the product grid"},
     "version": {"type": "string", "pattern": "^v\\d{3}$", "description": "Product version"},
     "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
   },
-  "template": "{variable}_{reference_year}_{resolution}_{eea_tile}_{epsg_code}_{version}[.{extension}]",
+  "template": "{variable}_{reference_year}_{resolution}_{tile_id}_{epsg_code}_{version}[.{extension}]",
   "examples": [
     "IBU_2018_010m_E47N18_03035_v010.tif",
     "IBU_2018_010m_E47N19_03035_v010.tif",

--- a/src/parseo/schemas/copernicus/clms/hrl/imp_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/imp_filename_v0_0_0.json
@@ -9,12 +9,12 @@
   "fields": {
     "variable": {"type": "string", "enum": ["IMD"], "description": "Product code"},
     "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
-    "eea_tile": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA, LAEA reference grid tile identifier"},
+    "tile_id": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA, LAEA reference grid tile identifier"},
     "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
     "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
     "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
   },
-  "template": "{variable}_{reference_year}_{eea_tile}_{resolution}_{version}[.{extension}]",
+  "template": "{variable}_{reference_year}_{tile_id}_{resolution}_{version}[.{extension}]",
   "examples": [
     "IMD_2021_E042N018_010m_V100.tif"
   ]

--- a/src/parseo/schemas/copernicus/clms/hrl/nvlcc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/nvlcc_filename_v0_0_0.json
@@ -32,7 +32,7 @@
       "pattern": "^R\\d{2,3}m$",
       "description": "Spatial resolution"
     },
-    "eea_tile": {
+    "tile_id": {
       "type": "string",
       "pattern": "^[EW]\\d{2}[NS]\\d{2}$",
       "description": "Tile identifier in the EEA 10m grid (easting/northing)"
@@ -58,7 +58,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "template": "{prefix}_{theme}_{variable}_{temporal_coverage}_{resolution}_{eea_tile}_{epsg_code}_{version}_{release}[.{extension}]",
+  "template": "{prefix}_{theme}_{variable}_{temporal_coverage}_{resolution}_{tile_id}_{epsg_code}_{version}_{release}[.{extension}]",
   "examples": [
     "CLMS_HRLNVLCC_IMCCS_C2018-2021_R20m_E09N27_03035_V01_R01.tif",
     "CLMS_HRLNVLCC_IMD_S2021_R10m_E09N27_03035_V01_R01.tif",

--- a/src/parseo/schemas/copernicus/clms/hrl/swf_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/swf_filename_v0_0_0.json
@@ -9,12 +9,12 @@
   "fields": {
     "variable": {"type": "string", "enum": ["SWF"], "description": "Product code"},
     "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
-    "eea_tile": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA, LAEA reference grid tile identifier"},
+    "tile_id": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA, LAEA reference grid tile identifier"},
     "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
     "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
     "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
   },
-  "template": "{variable}_{reference_year}_{eea_tile}_{resolution}_{version}[.{extension}]",
+  "template": "{variable}_{reference_year}_{tile_id}_{resolution}_{version}[.{extension}]",
   "examples": [
     "SWF_2018_E042N018_010m_V100.tif"
   ]

--- a/src/parseo/schemas/copernicus/clms/hrl/swf_filename_v0_0_1.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/swf_filename_v0_0_1.json
@@ -22,7 +22,7 @@
       "pattern": "^(?:005m|010m|020m|100m)$",
       "description": "Spatial resolution"
     },
-    "eea_tile": {
+    "tile_id": {
       "type": "string",
       "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
       "description": "EEA reference grid tile identifier"
@@ -38,7 +38,7 @@
       "description": "File extension without leading dot"
     }
   },
-  "template": "{variable}_{reference_year}_{resolution}_{eea_tile}_{epsg_code}[.{extension}]",
+  "template": "{variable}_{reference_year}_{resolution}_{tile_id}_{epsg_code}[.{extension}]",
   "examples": [
     "SWF_2018_005m_E34N27_03035.tif",
     "SWF_2018_005m_E36N31_03035.tif"

--- a/src/parseo/schemas/copernicus/clms/hrl/vlcc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/vlcc_filename_v0_0_0.json
@@ -27,11 +27,11 @@
       "pattern": "^(?:C\\d{4}(?:-\\d{4})?|P\\d{4}-\\d{4}|S\\d{4})$",
       "description": "Temporal coverage token where CYYYY or CYYYY-YYYY captures change layers, PYYYY-YYYY captures period aggregates, and SYYYY captures status layers"
     },
-    "type":{
+    "type": {
       "type": "string",
       "enum": ["R"],
       "description": "Data type Raster/Vector"
-    }
+    },
     "resolution": {
       "type": "string",
       "pattern": "^\\d{2,3}m$",

--- a/src/parseo/schemas/copernicus/clms/hrl/waw_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/waw_filename_v0_0_0.json
@@ -9,12 +9,12 @@
   "fields": {
     "variable": {"type": "string", "enum": ["WAW"], "description": "Product code"},
     "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
-    "eea_tile": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA, LAEA reference grid tile identifier"},
+    "tile_id": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA, LAEA reference grid tile identifier"},
     "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
     "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
     "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
   },
-  "template": "{variable}_{reference_year}_{eea_tile}_{resolution}_{version}[.{extension}]",
+  "template": "{variable}_{reference_year}_{tile_id}_{resolution}_{version}[.{extension}]",
   "examples": [
     "WAW_2018_E042N018_010m_V100.tif"
   ]

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -94,7 +94,7 @@ def test_assemble_clms_hrl_imperviousness():
     fields = {
         "variable": "IMD",
         "reference_year": "2021",
-        "eea_tile": "E042N018",
+        "tile_id": "E042N018",
         "resolution": "010m",
         "version": "V100",
         "extension": "tif",
@@ -108,7 +108,7 @@ def test_assemble_clms_n2k():
     fields = {
         "theme": "N2K",
         "reference": "2018",
-        "epsg_code": "EPSG3035",
+        "epsg_code": "03035",
         "version": "V1_0",
         "extension": "gpkg",
     }
@@ -148,7 +148,7 @@ def test_assemble_clms_clcplus_with_canonical_type():
         "type": "raster",
         "season": "S2023",
         "resolution": "R10m",
-        "eea_tile": "E48N37",
+        "tile_id": "E48N37",
         "epsg_code": "03035",
         "version": "V01",
         "revision": "R00",
@@ -223,14 +223,14 @@ def test_assemble_clms_hr_vpp_from_mgrs_tile():
     assert name == "VPP_2017_S2_T32TPR-010m_V101_s1_AMPL.tif"
 
 
-def test_assemble_clms_hr_vpp_from_eea_tile():
+def test_assemble_clms_hr_vpp_from_tile_id():
     fields = {
         "product": "VPP",
         "reference_year": "2017",
         "platform": "Sentinel-2",
         "constellation": "Sentinel-2",
         "instruments": ["MSI"],
-        "eea_tile": "E45N28",
+        "tile_id": "E45N28",
         "epsg_code": "03035",
         "resolution": "010m",
         "version": "V101",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -178,7 +178,6 @@ def test_parse_urban_atlas_lcu():
         "version": "V01",
         "revision": "R00",
         "production_date": "20240212",
-        "extension": None,
     }
     assert "type_code" not in result.fields
 
@@ -207,7 +206,7 @@ def test_parse_clms_hrl_nvlcc():
         "variable": "IMD",
         "temporal_coverage": "S2021",
         "resolution": "R10m",
-        "eea_tile": "E09N27",
+        "tile_id": "E09N27",
         "epsg_code": "03035",
         "version": "V01",
         "release": "R01",
@@ -234,7 +233,7 @@ def test_parse_clms_hrl_small_woody_features():
         "variable": "SWF",
         "reference_year": "2018",
         "resolution": "005m",
-        "eea_tile": "E34N27",
+        "tile_id": "E34N27",
         "epsg_code": "03035",
         "extension": "tif",
     }
@@ -249,7 +248,8 @@ def test_parse_clms_hrl_imperviousness():
     assert result.fields == {
         "variable": "IMD",
         "reference_year": "2021",
-        "eea_tile": "E042N018",
+        "tile_id": "E042N018",
+        "epsg_code": "03035",
         "resolution": "010m",
         "version": "V100",
         "extension": "tif",
@@ -365,17 +365,17 @@ def test_parse_clms_hr_vpp_mgrs_tile():
     assert result.match_family == "VPP"
     assert result.fields["tile"] == "T32TPR"
     assert result.fields["mgrs_tile"] == "T32TPR"
-    assert "eea_tile" not in result.fields
+    assert "tile_id" not in result.fields
 
 
-def test_parse_clms_hr_vpp_eea_tile():
+def test_parse_clms_hr_vpp_tile_id():
     name = "VPP_2017_S2_E45N28-03035-010m_V101_s1_EOSD.tif"
     result = parse_auto(name)
 
     assert result.valid
     assert result.match_family == "VPP"
     assert result.fields["tile"] == "E45N28"
-    assert result.fields["eea_tile"] == "E45N28"
+    assert result.fields["tile_id"] == "E45N28"
     assert result.fields["epsg_code"] == "03035"
     assert "mgrs_tile" not in result.fields
 
@@ -389,7 +389,7 @@ def test_parse_clms_n2k_change():
     assert result.fields == {
         "theme": "N2K_Change",
         "reference": "2012-2018",
-        "epsg_code": "EPSG3035",
+        "epsg_code": "03035",
         "version": "V2_0",
         "extension": "zip",
     }


### PR DESCRIPTION
## Summary
- rename the remaining eea_tile field handling in the parser utilities and propagate normalized tile IDs and EPSG codes for EEA tiles
- update Copernicus schema JSON files to expose tile_id tokens and revised templates, including optional epsg_code fields for HR-VPP products
- align parser and assembler tests with the tile_id field and new EPSG normalization behavior

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e2d5f68ea483279e9f723fc370cfe3