### PR TITLE
Format CLMS schema fields on multiple lines

### DIFF
--- a/src/parseo/schemas/copernicus/clms/clc/clc_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/clc/clc_filename_v1_0_0.json
@@ -12,7 +12,10 @@
   "fields": {
     "project": {
       "type": "string",
-      "enum": ["CLC", "U"],
+      "enum": [
+        "CLC",
+        "U"
+      ],
       "description": "Project code"
     },
     "reference_year": {
@@ -37,7 +40,9 @@
     },
     "extension": {
       "type": "string",
-      "enum": ["tif"],
+      "enum": [
+        "tif"
+      ],
       "description": "File extension without leading dot"
     }
   },

--- a/src/parseo/schemas/copernicus/clms/clc/clc_filename_v1_1_0.json
+++ b/src/parseo/schemas/copernicus/clms/clc/clc_filename_v1_1_0.json
@@ -14,7 +14,10 @@
     },
     "product": {
       "type": "string",
-      "enum": ["CLC", "CHA"],
+      "enum": [
+        "CLC",
+        "CHA"
+      ],
       "description": "Layer theme: CLC for status layers, CHA for change layers."
     },
     "reference_code": {

--- a/src/parseo/schemas/copernicus/clms/clcplus/ras/clcplus_filename_v0_0_1.json
+++ b/src/parseo/schemas/copernicus/clms/clcplus/ras/clcplus_filename_v0_0_1.json
@@ -4,26 +4,37 @@
   "schema_version": "0.0.1",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS CLC+ raster product filename (extension optional).",
   "fields": {
     "programme": {
       "type": "string",
-      "enum": ["CLMS"],
+      "enum": [
+        "CLMS"
+      ],
       "description": "Copernicus Land Monitoring Service programme identifier"
     },
     "product": {
       "type": "string",
-      "enum": ["CLCPLUS"],
+      "enum": [
+        "CLCPLUS"
+      ],
       "description": "Product family identifier"
     },
     "type": {
       "type": "string",
-      "enum": ["RAS"],
+      "enum": [
+        "RAS"
+      ],
       "description": "Data class code (raster)",
       "stac_map": {
         "values": {
-          "RAS": {"type": "raster"}
+          "RAS": {
+            "type": "raster"
+          }
         }
       }
     },
@@ -59,7 +70,9 @@
     },
     "extension": {
       "type": "string",
-      "enum": ["tif"],
+      "enum": [
+        "tif"
+      ],
       "description": "File extension without leading dot"
     }
   },

--- a/src/parseo/schemas/copernicus/clms/egms/egms_gnss_model_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/egms/egms_gnss_model_filename_v0_0_0.json
@@ -8,12 +8,16 @@
   "fields": {
     "product": {
       "type": "string",
-      "enum": ["EGMS"],
+      "enum": [
+        "EGMS"
+      ],
       "description": "Constant service prefix"
     },
     "variable": {
       "type": "string",
-      "enum": ["AEPND"],
+      "enum": [
+        "AEPND"
+      ],
       "description": "Product identifier"
     },
     "issue_year": {
@@ -28,7 +32,9 @@
     },
     "extension": {
       "type": "string",
-      "enum": ["csv"],
+      "enum": [
+        "csv"
+      ],
       "description": "File extension without leading dot"
     }
   },

--- a/src/parseo/schemas/copernicus/clms/egms/egms_l2a_product_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/egms/egms_l2a_product_filename_v0_0_0.json
@@ -8,7 +8,9 @@
   "fields": {
     "product": {
       "type": "string",
-      "enum": ["EGMS"],
+      "enum": [
+        "EGMS"
+      ],
       "description": "Constant service prefix"
     },
     "level": {
@@ -53,7 +55,10 @@
     },
     "extension": {
       "type": "string",
-      "enum": ["csv", "zip"],
+      "enum": [
+        "csv",
+        "zip"
+      ],
       "description": "File extension without leading dot"
     }
   },

--- a/src/parseo/schemas/copernicus/clms/egms/egms_l3_velocity_grid_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/egms/egms_l3_velocity_grid_filename_v0_0_0.json
@@ -4,12 +4,16 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json"
+  ],
   "description": "Copernicus European Ground Motion Service Level 3 velocity grid filename (extension optional).",
   "fields": {
     "product": {
       "type": "string",
-      "enum": ["EGMS"],
+      "enum": [
+        "EGMS"
+      ],
       "description": "Constant service prefix"
     },
     "level": {
@@ -49,7 +53,10 @@
     },
     "extension": {
       "type": "string",
-      "enum": ["tif", "tiff"],
+      "enum": [
+        "tif",
+        "tiff"
+      ],
       "description": "File extension without leading dot"
     }
   },

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/st_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/st_filename_v0_0_0.json
@@ -4,12 +4,31 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS HR-VPP Seasonal Trajectories Plant Phenology Index product filename (extension optional).",
   "fields": {
-    "product": {"type": "string", "enum": ["ST"], "description": "Constant prefix"},
-    "timestamp": {"type": "string", "pattern": "^\\d{8}T\\d{6}$", "description": "Acquisition timestamp (YYYYMMDDTHHMMSS)"},
-    "sensor": {"type": "string", "enum": ["S2"], "description": "Sensor platform"},
+    "product": {
+      "type": "string",
+      "enum": [
+        "ST"
+      ],
+      "description": "Constant prefix"
+    },
+    "timestamp": {
+      "type": "string",
+      "pattern": "^\\d{8}T\\d{6}$",
+      "description": "Acquisition timestamp (YYYYMMDDTHHMMSS)"
+    },
+    "sensor": {
+      "type": "string",
+      "enum": [
+        "S2"
+      ],
+      "description": "Sensor platform"
+    },
     "tile_id": {
       "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
       "oneOf": [
@@ -30,14 +49,31 @@
       "pattern": "^\\d{4,5}$",
       "description": "EPSG code of the product grid (unpadded values are zero-filled on output)"
     },
-    "resolution": {"type": "string", "pattern": "^\\d{3}m$", "description": "Spatial resolution"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
+    "resolution": {
+      "type": "string",
+      "pattern": "^\\d{3}m$",
+      "description": "Spatial resolution"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
     "variable": {
       "type": "string",
-      "enum": ["PPI", "QFLAG"],
+      "enum": [
+        "PPI",
+        "QFLAG"
+      ],
       "description": "Product code"
     },
-    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{product}_{timestamp}_{sensor}_{tile_id}[-{epsg_code}]-{resolution}_{version}_{variable}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/vi_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/vi_filename_v0_0_0.json
@@ -4,27 +4,43 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "Copernicus Land Monitoring Service Vegetation Index filename schema covering the HR-VPP suite (FAPAR, LAI, NDVI, PPI, FCOVER, DMP).",
   "fields": {
     "programme": {
       "type": "string",
-      "enum": ["CLMS"],
+      "enum": [
+        "CLMS"
+      ],
       "description": "Programme prefix (Copernicus Land Monitoring Service)"
     },
     "product": {
       "type": "string",
-      "enum": ["VPP"],
+      "enum": [
+        "VPP"
+      ],
       "description": "Product family identifier (Vegetation Phenology & Productivity)"
     },
     "parameter": {
       "type": "string",
-      "enum": ["FAPAR", "LAI", "NDVI", "PPI", "FCOVER", "DMP"],
+      "enum": [
+        "FAPAR",
+        "LAI",
+        "NDVI",
+        "PPI",
+        "FCOVER",
+        "DMP"
+      ],
       "description": "Biophysical variable encoded in the product"
     },
     "resolution": {
       "type": "string",
-      "enum": ["100m"],
+      "enum": [
+        "100m"
+      ],
       "description": "Spatial resolution of the raster"
     },
     "tile_id": {
@@ -49,12 +65,23 @@
     },
     "variable": {
       "type": "string",
-      "enum": ["FAPAR", "LAI", "NDVI", "PPI", "FCOVER", "DMP", "MTD"],
+      "enum": [
+        "FAPAR",
+        "LAI",
+        "NDVI",
+        "PPI",
+        "FCOVER",
+        "DMP",
+        "MTD"
+      ],
       "description": "Filename suffix indicating product content"
     },
     "extension": {
       "type": "string",
-      "enum": ["tif", "xml"],
+      "enum": [
+        "tif",
+        "xml"
+      ],
       "description": "File extension without leading dot"
     }
   },

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/vpp_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/vpp_filename_v0_0_0.json
@@ -12,7 +12,9 @@
   "fields": {
     "product": {
       "type": "string",
-      "enum": ["VPP"],
+      "enum": [
+        "VPP"
+      ],
       "description": "Product family prefix (Vegetation Phenology and Productivity)"
     },
     "reference_year": {
@@ -22,13 +24,17 @@
     },
     "sensor": {
       "type": "string",
-      "enum": ["S2"],
+      "enum": [
+        "S2"
+      ],
       "description": "Sensor platform",
       "stac_map": {
         "S2": {
           "platform": "Sentinel-2",
           "constellation": "Sentinel-2",
-          "instruments": ["MSI"]
+          "instruments": [
+            "MSI"
+          ]
         }
       }
     },
@@ -64,7 +70,10 @@
     },
     "season": {
       "type": "string",
-      "enum": ["s1", "s2"],
+      "enum": [
+        "s1",
+        "s2"
+      ],
       "description": "Season identifier (s1 = first season, s2 = second season)"
     },
     "variable": {
@@ -89,7 +98,9 @@
     },
     "extension": {
       "type": "string",
-      "enum": ["tif"],
+      "enum": [
+        "tif"
+      ],
       "description": "File extension without leading dot"
     }
   },

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/cc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/cc_filename_v0_0_0.json
@@ -4,27 +4,82 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS HR-WSI Cloud Cover product filename (extension optional).",
   "fields": {
     "programme": {
       "type": "string",
-      "enum": ["CLMS"],
+      "enum": [
+        "CLMS"
+      ],
       "description": "Constant programme prefix"
     },
     "project": {
-      "type": "string", 
-      "enum": ["WSI"], 
+      "type": "string",
+      "enum": [
+        "WSI"
+      ],
       "description": "Project"
-  },
-    "product": {"type": "string", "enum": ["CC"], "description": "Product code"},
-    "pixel_spacing": {"type": "string", "enum": ["020m"], "description": "Pixel spacing"},
-    "mgrs_tile": {"type": "string", "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$", "description": "MGRS tile identifier"},
-    "sensing_datetime": {"type": "string", "pattern": "^\\d{8}T\\d{6}$", "description": "Acquisition datetime (UTC)"},
-    "platform": {"type": "string", "enum": ["S2A", "S2B", "S2C"], "description": "Satellite platform"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "variable": {"type": "string", "enum": ["CC", "CC-QA", "QAFLAGS", "MTD"], "description": "File identifier"},
-    "extension": {"type": "string", "enum": ["tif", "xml"], "description": "File extension without leading dot"}
+    },
+    "product": {
+      "type": "string",
+      "enum": [
+        "CC"
+      ],
+      "description": "Product code"
+    },
+    "pixel_spacing": {
+      "type": "string",
+      "enum": [
+        "020m"
+      ],
+      "description": "Pixel spacing"
+    },
+    "mgrs_tile": {
+      "type": "string",
+      "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+      "description": "MGRS tile identifier"
+    },
+    "sensing_datetime": {
+      "type": "string",
+      "pattern": "^\\d{8}T\\d{6}$",
+      "description": "Acquisition datetime (UTC)"
+    },
+    "platform": {
+      "type": "string",
+      "enum": [
+        "S2A",
+        "S2B",
+        "S2C"
+      ],
+      "description": "Satellite platform"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "variable": {
+      "type": "string",
+      "enum": [
+        "CC",
+        "CC-QA",
+        "QAFLAGS",
+        "MTD"
+      ],
+      "description": "File identifier"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif",
+        "xml"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{programme}_{project}_{product}_{pixel_spacing}_{mgrs_tile}_{sensing_datetime}_{platform}_{version}_{variable}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/fsc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/fsc_filename_v0_0_0.json
@@ -4,25 +4,64 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS HR-WSI Fractional Snow Cover product filename (extension optional).",
   "fields": {
     "programme": {
       "type": "string",
-      "enum": ["CLMS"],
+      "enum": [
+        "CLMS"
+      ],
       "description": "Constant programme prefix"
     },
     "project": {
-      "type": "string", 
-      "enum": ["WSI"], 
+      "type": "string",
+      "enum": [
+        "WSI"
+      ],
       "description": "Project"
-    },    
-    "product": {"type": "string", "enum": ["FSC"], "description": "Product code"},
-    "pixel_spacing": {"type": "string", "enum": ["020m"], "description": "Pixel spacing"},
-    "mgrs_tile": {"type": "string", "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$", "description": "MGRS tile identifier"},
-    "sensing_datetime": {"type": "string", "pattern": "^\\d{8}T\\d{6}$", "description": "Acquisition datetime (UTC)"},
-    "platform": {"type": "string", "enum": ["S2A", "S2B", "S2C"], "description": "Satellite platform"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
+    },
+    "product": {
+      "type": "string",
+      "enum": [
+        "FSC"
+      ],
+      "description": "Product code"
+    },
+    "pixel_spacing": {
+      "type": "string",
+      "enum": [
+        "020m"
+      ],
+      "description": "Pixel spacing"
+    },
+    "mgrs_tile": {
+      "type": "string",
+      "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+      "description": "MGRS tile identifier"
+    },
+    "sensing_datetime": {
+      "type": "string",
+      "pattern": "^\\d{8}T\\d{6}$",
+      "description": "Acquisition datetime (UTC)"
+    },
+    "platform": {
+      "type": "string",
+      "enum": [
+        "S2A",
+        "S2B",
+        "S2C"
+      ],
+      "description": "Satellite platform"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
     "variable": {
       "type": "string",
       "enum": [
@@ -37,7 +76,14 @@
       ],
       "description": "File identifier"
     },
-    "extension": {"type": "string", "enum": ["tif", "xml"], "description": "File extension without leading dot"}
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif",
+        "xml"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{programme}_{project}_{product}_{pixel_spacing}_{mgrs_tile}_{sensing_datetime}_{platform}_{version}_{variable}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/gfsc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/gfsc_filename_v0_0_0.json
@@ -4,31 +4,81 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS HR-WSI Gap-filled Fractional Snow Cover product filename (extension optional).",
   "fields": {
     "programme": {
       "type": "string",
-      "enum": ["CLMS"],
+      "enum": [
+        "CLMS"
+      ],
       "description": "Constant programme prefix"
     },
     "project": {
       "type": "string",
-      "enum": ["WSI"],
+      "enum": [
+        "WSI"
+      ],
       "description": "Project"
     },
-    "product": {"type": "string", "enum": ["GFSC"], "description": "Product code"},
-    "pixel_spacing": {"type": "string", "enum": ["060m"], "description": "Pixel spacing"},
-    "mgrs_tile": {"type": "string", "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$", "description": "MGRS tile identifier"},
-    "period": {"type": "string", "pattern": "^\\d{8}P7D$", "description": "Aggregation period"},
-    "combination": {"type": "string", "enum": ["COMB"], "description": "Combination method"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
+    "product": {
+      "type": "string",
+      "enum": [
+        "GFSC"
+      ],
+      "description": "Product code"
+    },
+    "pixel_spacing": {
+      "type": "string",
+      "enum": [
+        "060m"
+      ],
+      "description": "Pixel spacing"
+    },
+    "mgrs_tile": {
+      "type": "string",
+      "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+      "description": "MGRS tile identifier"
+    },
+    "period": {
+      "type": "string",
+      "pattern": "^\\d{8}P7D$",
+      "description": "Aggregation period"
+    },
+    "combination": {
+      "type": "string",
+      "enum": [
+        "COMB"
+      ],
+      "description": "Combination method"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
     "variable": {
       "type": "string",
-      "enum": ["AT", "GF", "GF-QA", "MTD", "QAFLAGS"],
+      "enum": [
+        "AT",
+        "GF",
+        "GF-QA",
+        "MTD",
+        "QAFLAGS"
+      ],
       "description": "File identifier"
     },
-    "extension": {"type": "string", "enum": ["tif", "xml"], "description": "File extension without leading dot"}
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif",
+        "xml"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{programme}_{project}_{product}_{pixel_spacing}_{mgrs_tile}_{period}_{combination}_{version}_{variable}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/icd_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/icd_filename_v0_0_0.json
@@ -4,21 +4,41 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS HR-WSI Ice Cover Duration product filename (extension optional).",
   "fields": {
     "programme": {
       "type": "string",
-      "enum": ["CLMS"],
+      "enum": [
+        "CLMS"
+      ],
       "description": "Constant programme prefix"
     },
     "project": {
       "type": "string",
-      "enum": ["WSI"],
+      "enum": [
+        "WSI"
+      ],
       "description": "Project"
     },
-    "product": {"type": "string", "enum": ["ICD"], "description": "Product code"},
-    "pixel_spacing": {"type": "string", "enum": ["020m", "100m"], "description": "Pixel spacing"},
+    "product": {
+      "type": "string",
+      "enum": [
+        "ICD"
+      ],
+      "description": "Product code"
+    },
+    "pixel_spacing": {
+      "type": "string",
+      "enum": [
+        "020m",
+        "100m"
+      ],
+      "description": "Pixel spacing"
+    },
     "tile_id": {
       "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
       "oneOf": [
@@ -34,11 +54,42 @@
         }
       ]
     },
-    "period_start": {"type": "string", "pattern": "^\\d{8}P1Y$", "description": "Aggregation period start"},
-    "combination": {"type": "string", "enum": ["COMB"], "description": "Combination method"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "variable": {"type": "string", "enum": ["ICD", "NOBS1", "NOBS2", "ICD-QA", "MTD"], "description": "File identifier"},
-    "extension": {"type": "string", "enum": ["tif", "xml"], "description": "File extension without leading dot"}
+    "period_start": {
+      "type": "string",
+      "pattern": "^\\d{8}P1Y$",
+      "description": "Aggregation period start"
+    },
+    "combination": {
+      "type": "string",
+      "enum": [
+        "COMB"
+      ],
+      "description": "Combination method"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "variable": {
+      "type": "string",
+      "enum": [
+        "ICD",
+        "NOBS1",
+        "NOBS2",
+        "ICD-QA",
+        "MTD"
+      ],
+      "description": "File identifier"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif",
+        "xml"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{programme}_{project}_{product}_{pixel_spacing}_{tile_id}_{period_start}_{combination}_{version}_{variable}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/sp_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/sp_filename_v0_0_0.json
@@ -12,22 +12,32 @@
   "fields": {
     "programme": {
       "type": "string",
-      "enum": ["CLMS"],
+      "enum": [
+        "CLMS"
+      ],
       "description": "Constant programme prefix"
     },
     "project": {
       "type": "string",
-      "enum": ["WSI"],
+      "enum": [
+        "WSI"
+      ],
       "description": "Project"
     },
     "product": {
       "type": "string",
-      "enum": ["SP"],
+      "enum": [
+        "SP"
+      ],
       "description": "Product code"
     },
     "pixel_spacing": {
       "type": "string",
-      "enum": ["020m", "060m", "100m"],
+      "enum": [
+        "020m",
+        "060m",
+        "100m"
+      ],
       "description": "Pixel spacing"
     },
     "tile_id": {
@@ -52,7 +62,10 @@
     },
     "variant": {
       "type": "string",
-      "enum": ["S2", "COMB"],
+      "enum": [
+        "S2",
+        "COMB"
+      ],
       "description": "Source mission or combination method"
     },
     "version": {
@@ -79,7 +92,10 @@
     },
     "extension": {
       "type": "string",
-      "enum": ["tif", "xml"],
+      "enum": [
+        "tif",
+        "xml"
+      ],
       "description": "File extension without leading dot"
     }
   },
@@ -87,14 +103,21 @@
     {
       "if": {
         "properties": {
-          "variant": {"const": "S2"}
+          "variant": {
+            "const": "S2"
+          }
         },
-        "required": ["variant"]
+        "required": [
+          "variant"
+        ]
       },
       "then": {
         "properties": {
           "pixel_spacing": {
-            "enum": ["020m", "100m"]
+            "enum": [
+              "020m",
+              "100m"
+            ]
           },
           "variable": {
             "enum": [
@@ -115,14 +138,21 @@
     {
       "if": {
         "properties": {
-          "variant": {"const": "COMB"}
+          "variant": {
+            "const": "COMB"
+          }
         },
-        "required": ["variant"]
+        "required": [
+          "variant"
+        ]
       },
       "then": {
         "properties": {
           "pixel_spacing": {
-            "enum": ["060m", "100m"]
+            "enum": [
+              "060m",
+              "100m"
+            ]
           },
           "variable": {
             "enum": [

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/sws_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/sws_filename_v0_0_0.json
@@ -4,27 +4,81 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS HR-WSI Small Water Surface product filename (extension optional).",
   "fields": {
     "programme": {
       "type": "string",
-      "enum": ["CLMS"],
+      "enum": [
+        "CLMS"
+      ],
       "description": "Constant programme prefix"
     },
     "project": {
       "type": "string",
-      "enum": ["WSI"],
+      "enum": [
+        "WSI"
+      ],
       "description": "Project"
     },
-    "product": {"type": "string", "enum": ["SWS"], "description": "Product code"},
-    "pixel_spacing": {"type": "string", "enum": ["060m"], "description": "Pixel spacing"},
-    "mgrs_tile": {"type": "string", "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$", "description": "MGRS tile identifier"},
-    "sensing_datetime": {"type": "string", "pattern": "^\\d{8}T\\d{6}$", "description": "Acquisition datetime (UTC)"},
-    "platform": {"type": "string", "enum": ["S1A", "S1B", "S1C"], "description": "Satellite platform"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "variable": {"type": "string", "enum": ["WSM", "WSM-QA", "MTD"], "description": "File identifier"},
-    "extension": {"type": "string", "enum": ["tif", "xml"], "description": "File extension without leading dot"}
+    "product": {
+      "type": "string",
+      "enum": [
+        "SWS"
+      ],
+      "description": "Product code"
+    },
+    "pixel_spacing": {
+      "type": "string",
+      "enum": [
+        "060m"
+      ],
+      "description": "Pixel spacing"
+    },
+    "mgrs_tile": {
+      "type": "string",
+      "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+      "description": "MGRS tile identifier"
+    },
+    "sensing_datetime": {
+      "type": "string",
+      "pattern": "^\\d{8}T\\d{6}$",
+      "description": "Acquisition datetime (UTC)"
+    },
+    "platform": {
+      "type": "string",
+      "enum": [
+        "S1A",
+        "S1B",
+        "S1C"
+      ],
+      "description": "Satellite platform"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "variable": {
+      "type": "string",
+      "enum": [
+        "WSM",
+        "WSM-QA",
+        "MTD"
+      ],
+      "description": "File identifier"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif",
+        "xml"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{programme}_{project}_{product}_{pixel_spacing}_{mgrs_tile}_{sensing_datetime}_{platform}_{version}_{variable}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/wds_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/wds_filename_v0_0_0.json
@@ -4,27 +4,81 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS HR-WSI Water Detection and Surface Displacement product filename (extension optional).",
   "fields": {
     "programme": {
       "type": "string",
-      "enum": ["CLMS"],
+      "enum": [
+        "CLMS"
+      ],
       "description": "Constant programme prefix"
     },
     "project": {
       "type": "string",
-      "enum": ["WSI"],
+      "enum": [
+        "WSI"
+      ],
       "description": "Project"
     },
-    "product": {"type": "string", "enum": ["WDS"], "description": "Product code"},
-    "pixel_spacing": {"type": "string", "enum": ["060m"], "description": "Pixel spacing"},
-    "mgrs_tile": {"type": "string", "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$", "description": "MGRS tile identifier"},
-    "sensing_datetime": {"type": "string", "pattern": "^\\d{8}T\\d{6}$", "description": "Acquisition datetime (UTC)"},
-    "platform": {"type": "string", "enum": ["S1A", "S1B", "S1C"], "description": "Satellite platform"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "variable": {"type": "string", "enum": ["SSC", "SSC-QA", "MTD"], "description": "File identifier"},
-    "extension": {"type": "string", "enum": ["tif", "xml"], "description": "File extension without leading dot"}
+    "product": {
+      "type": "string",
+      "enum": [
+        "WDS"
+      ],
+      "description": "Product code"
+    },
+    "pixel_spacing": {
+      "type": "string",
+      "enum": [
+        "060m"
+      ],
+      "description": "Pixel spacing"
+    },
+    "mgrs_tile": {
+      "type": "string",
+      "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+      "description": "MGRS tile identifier"
+    },
+    "sensing_datetime": {
+      "type": "string",
+      "pattern": "^\\d{8}T\\d{6}$",
+      "description": "Acquisition datetime (UTC)"
+    },
+    "platform": {
+      "type": "string",
+      "enum": [
+        "S1A",
+        "S1B",
+        "S1C"
+      ],
+      "description": "Satellite platform"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "variable": {
+      "type": "string",
+      "enum": [
+        "SSC",
+        "SSC-QA",
+        "MTD"
+      ],
+      "description": "File identifier"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif",
+        "xml"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{programme}_{project}_{product}_{pixel_spacing}_{mgrs_tile}_{sensing_datetime}_{platform}_{version}_{variable}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/wic_comb_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/wic_comb_filename_v0_0_0.json
@@ -4,27 +4,80 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS HR-WSI Water and Ice Cover combination filename (extension optional).",
   "fields": {
     "programme": {
       "type": "string",
-      "enum": ["CLMS"],
+      "enum": [
+        "CLMS"
+      ],
       "description": "Constant programme prefix"
     },
     "project": {
       "type": "string",
-      "enum": ["WSI"],
+      "enum": [
+        "WSI"
+      ],
       "description": "Project"
     },
-    "product": {"type": "string", "enum": ["WIC"], "description": "Product code"},
-    "pixel_spacing": {"type": "string", "enum": ["020m"], "description": "Pixel spacing"},
-    "mgrs_tile": {"type": "string", "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$", "description": "MGRS tile identifier"},
-    "period_start": {"type": "string", "pattern": "^\\d{8}T(?:00|12)0000P12H$", "description": "Aggregation period start"},
-    "combination": {"type": "string", "enum": ["COMB"], "description": "Combination method"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "variable": {"type": "string", "enum": ["WIC", "QAFLAGS", "WIC-QA", "MTD"], "description": "File identifier"},
-    "extension": {"type": "string", "enum": ["tif", "xml"], "description": "File extension without leading dot"}
+    "product": {
+      "type": "string",
+      "enum": [
+        "WIC"
+      ],
+      "description": "Product code"
+    },
+    "pixel_spacing": {
+      "type": "string",
+      "enum": [
+        "020m"
+      ],
+      "description": "Pixel spacing"
+    },
+    "mgrs_tile": {
+      "type": "string",
+      "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+      "description": "MGRS tile identifier"
+    },
+    "period_start": {
+      "type": "string",
+      "pattern": "^\\d{8}T(?:00|12)0000P12H$",
+      "description": "Aggregation period start"
+    },
+    "combination": {
+      "type": "string",
+      "enum": [
+        "COMB"
+      ],
+      "description": "Combination method"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "variable": {
+      "type": "string",
+      "enum": [
+        "WIC",
+        "QAFLAGS",
+        "WIC-QA",
+        "MTD"
+      ],
+      "description": "File identifier"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif",
+        "xml"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{programme}_{project}_{product}_{pixel_spacing}_{mgrs_tile}_{period_start}_{combination}_{version}_{variable}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/wic_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/wic_filename_v0_0_0.json
@@ -4,27 +4,87 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS HR-WSI Water and Ice Cover Sentinel-1 and Sentinel-2 product filename (extension optional).",
   "fields": {
     "programme": {
       "type": "string",
-      "enum": ["CLMS"],
+      "enum": [
+        "CLMS"
+      ],
       "description": "Constant programme prefix"
     },
     "project": {
       "type": "string",
-      "enum": ["WSI"],
+      "enum": [
+        "WSI"
+      ],
       "description": "Project"
     },
-    "product": {"type": "string", "enum": ["WIC"], "description": "Product code"},
-    "pixel_spacing": {"type": "string", "enum": ["020m", "060m"], "description": "Pixel spacing"},
-    "mgrs_tile": {"type": "string", "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$", "description": "MGRS tile identifier"},
-    "sensing_datetime": {"type": "string", "pattern": "^\\d{8}T\\d{6}$", "description": "Acquisition datetime (UTC)"},
-    "platform": {"type": "string", "enum": ["S1A", "S1B", "S1C", "S2A", "S2B", "S2C"], "description": "Satellite platform"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "variable": {"type": "string", "enum": ["WIC", "PRB", "QAFLAGS", "WIC-QA", "MTD"], "description": "File identifier"},
-    "extension": {"type": "string", "enum": ["tif", "xml"], "description": "File extension without leading dot"}
+    "product": {
+      "type": "string",
+      "enum": [
+        "WIC"
+      ],
+      "description": "Product code"
+    },
+    "pixel_spacing": {
+      "type": "string",
+      "enum": [
+        "020m",
+        "060m"
+      ],
+      "description": "Pixel spacing"
+    },
+    "mgrs_tile": {
+      "type": "string",
+      "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+      "description": "MGRS tile identifier"
+    },
+    "sensing_datetime": {
+      "type": "string",
+      "pattern": "^\\d{8}T\\d{6}$",
+      "description": "Acquisition datetime (UTC)"
+    },
+    "platform": {
+      "type": "string",
+      "enum": [
+        "S1A",
+        "S1B",
+        "S1C",
+        "S2A",
+        "S2B",
+        "S2C"
+      ],
+      "description": "Satellite platform"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "variable": {
+      "type": "string",
+      "enum": [
+        "WIC",
+        "PRB",
+        "QAFLAGS",
+        "WIC-QA",
+        "MTD"
+      ],
+      "description": "File identifier"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif",
+        "xml"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{programme}_{project}_{product}_{pixel_spacing}_{mgrs_tile}_{sensing_datetime}_{platform}_{version}_{variable}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hrl/fty_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/fty_filename_v0_0_0.json
@@ -4,15 +4,46 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS High Resolution Layer Forest Type product filename (extension optional).",
   "fields": {
-    "variable": {"type": "string", "enum": ["FTY"], "description": "Product code"},
-    "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
-    "tile_id": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA, LAEA reference grid tile identifier"},
-    "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+    "variable": {
+      "type": "string",
+      "enum": [
+        "FTY"
+      ],
+      "description": "Product code"
+    },
+    "reference_year": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "Reference year"
+    },
+    "tile_id": {
+      "type": "string",
+      "pattern": "^[EW]\\d{3}[NS]\\d{3}$",
+      "description": "EEA, LAEA reference grid tile identifier"
+    },
+    "resolution": {
+      "type": "string",
+      "pattern": "^(010m|020m|100m)$",
+      "description": "Spatial resolution"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{variable}_{reference_year}_{tile_id}_{resolution}_{version}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hrl/gra_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/gra_filename_v0_0_0.json
@@ -4,15 +4,46 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS High Resolution Layer Grassland product filename (extension optional).",
   "fields": {
-    "variable": {"type": "string", "enum": ["GRA"], "description": "Product code"},
-    "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
-    "tile_id": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA, LAEA reference grid tile identifier"},
-    "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+    "variable": {
+      "type": "string",
+      "enum": [
+        "GRA"
+      ],
+      "description": "Product code"
+    },
+    "reference_year": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "Reference year"
+    },
+    "tile_id": {
+      "type": "string",
+      "pattern": "^[EW]\\d{3}[NS]\\d{3}$",
+      "description": "EEA, LAEA reference grid tile identifier"
+    },
+    "resolution": {
+      "type": "string",
+      "pattern": "^(010m|020m|100m)$",
+      "description": "Spatial resolution"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{variable}_{reference_year}_{tile_id}_{resolution}_{version}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hrl/ibu_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/ibu_filename_v0_0_0.json
@@ -4,16 +4,51 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS High Resolution Layer Impervious Built-up Area product filename (extension optional).",
   "fields": {
-    "variable": {"type": "string", "enum": ["IBU"], "description": "Product code"},
-    "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
-    "resolution": {"type": "string", "pattern": "^\\d{3}m$", "description": "Spatial resolution in metres with leading zeros"},
-    "tile_id": {"type": "string", "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$", "description": "EEA reference grid tile identifier"},
-    "epsg_code": {"type": "string", "pattern": "^\\d{5}$", "description": "EPSG code of the product grid"},
-    "version": {"type": "string", "pattern": "^v\\d{3}$", "description": "Product version"},
-    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+    "variable": {
+      "type": "string",
+      "enum": [
+        "IBU"
+      ],
+      "description": "Product code"
+    },
+    "reference_year": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "Reference year"
+    },
+    "resolution": {
+      "type": "string",
+      "pattern": "^\\d{3}m$",
+      "description": "Spatial resolution in metres with leading zeros"
+    },
+    "tile_id": {
+      "type": "string",
+      "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+      "description": "EEA reference grid tile identifier"
+    },
+    "epsg_code": {
+      "type": "string",
+      "pattern": "^\\d{5}$",
+      "description": "EPSG code of the product grid"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^v\\d{3}$",
+      "description": "Product version"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{variable}_{reference_year}_{resolution}_{tile_id}_{epsg_code}_{version}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hrl/imp_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/imp_filename_v0_0_0.json
@@ -4,15 +4,46 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS High Resolution Layer Imperviousness product filename (extension optional).",
   "fields": {
-    "variable": {"type": "string", "enum": ["IMD"], "description": "Product code"},
-    "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
-    "tile_id": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA, LAEA reference grid tile identifier"},
-    "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+    "variable": {
+      "type": "string",
+      "enum": [
+        "IMD"
+      ],
+      "description": "Product code"
+    },
+    "reference_year": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "Reference year"
+    },
+    "tile_id": {
+      "type": "string",
+      "pattern": "^[EW]\\d{3}[NS]\\d{3}$",
+      "description": "EEA, LAEA reference grid tile identifier"
+    },
+    "resolution": {
+      "type": "string",
+      "pattern": "^(010m|020m|100m)$",
+      "description": "Spatial resolution"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{variable}_{reference_year}_{tile_id}_{resolution}_{version}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hrl/nvlcc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/nvlcc_filename_v0_0_0.json
@@ -4,17 +4,24 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS High Resolution Layer Non-Vegetated Land Cover Characteristics product filename (extension optional).",
   "fields": {
     "prefix": {
       "type": "string",
-      "enum": ["CLMS"],
+      "enum": [
+        "CLMS"
+      ],
       "description": "Constant program prefix"
     },
     "theme": {
       "type": "string",
-      "enum": ["HRLNVLCC"],
+      "enum": [
+        "HRLNVLCC"
+      ],
       "description": "High Resolution Layer theme identifier"
     },
     "variable": {
@@ -54,7 +61,9 @@
     },
     "extension": {
       "type": "string",
-      "enum": ["tif"],
+      "enum": [
+        "tif"
+      ],
       "description": "File extension without leading dot"
     }
   },

--- a/src/parseo/schemas/copernicus/clms/hrl/swf_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/swf_filename_v0_0_0.json
@@ -4,15 +4,46 @@
   "schema_version": "0.0.0",
   "status": "deprecated",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS High Resolution Layer Small Woody Features product filename (extension optional).",
   "fields": {
-    "variable": {"type": "string", "enum": ["SWF"], "description": "Product code"},
-    "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
-    "tile_id": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA, LAEA reference grid tile identifier"},
-    "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+    "variable": {
+      "type": "string",
+      "enum": [
+        "SWF"
+      ],
+      "description": "Product code"
+    },
+    "reference_year": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "Reference year"
+    },
+    "tile_id": {
+      "type": "string",
+      "pattern": "^[EW]\\d{3}[NS]\\d{3}$",
+      "description": "EEA, LAEA reference grid tile identifier"
+    },
+    "resolution": {
+      "type": "string",
+      "pattern": "^(010m|020m|100m)$",
+      "description": "Spatial resolution"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{variable}_{reference_year}_{tile_id}_{resolution}_{version}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hrl/swf_filename_v0_0_1.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/swf_filename_v0_0_1.json
@@ -4,12 +4,17 @@
   "schema_version": "0.0.1",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS High Resolution Layer Small Woody Features product filename (extension optional).",
   "fields": {
     "variable": {
       "type": "string",
-      "enum": ["SWF"],
+      "enum": [
+        "SWF"
+      ],
       "description": "Product code"
     },
     "reference_year": {
@@ -34,7 +39,9 @@
     },
     "extension": {
       "type": "string",
-      "enum": ["tif"],
+      "enum": [
+        "tif"
+      ],
       "description": "File extension without leading dot"
     }
   },

--- a/src/parseo/schemas/copernicus/clms/hrl/tcd_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/tcd_filename_v0_0_0.json
@@ -4,15 +4,46 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS High Resolution Layer Tree Cover Density product filename (extension optional).",
   "fields": {
-    "variable": {"type": "string", "enum": ["TCD"], "description": "Product code"},
-    "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
-    "tile_id": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA, LAEA reference grid tile identifier"},
-    "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+    "variable": {
+      "type": "string",
+      "enum": [
+        "TCD"
+      ],
+      "description": "Product code"
+    },
+    "reference_year": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "Reference year"
+    },
+    "tile_id": {
+      "type": "string",
+      "pattern": "^[EW]\\d{3}[NS]\\d{3}$",
+      "description": "EEA, LAEA reference grid tile identifier"
+    },
+    "resolution": {
+      "type": "string",
+      "pattern": "^(010m|020m|100m)$",
+      "description": "Spatial resolution"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{variable}_{reference_year}_{tile_id}_{resolution}_{version}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/hrl/vlcc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/vlcc_filename_v0_0_0.json
@@ -4,17 +4,24 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS High Resolution Layer Vegetated Land Cover Characteristics product filename (extension optional).",
   "fields": {
     "programme": {
       "type": "string",
-      "enum": ["CLMS"],
+      "enum": [
+        "CLMS"
+      ],
       "description": "Constant program prefix"
     },
     "product": {
       "type": "string",
-      "enum": ["HRLVLCC"],
+      "enum": [
+        "HRLVLCC"
+      ],
       "description": "High Resolution Layer theme identifier"
     },
     "variable": {
@@ -29,7 +36,9 @@
     },
     "type": {
       "type": "string",
-      "enum": ["R"],
+      "enum": [
+        "R"
+      ],
       "description": "Data type Raster/Vector"
     },
     "resolution": {
@@ -59,7 +68,9 @@
     },
     "extension": {
       "type": "string",
-      "enum": ["tif"],
+      "enum": [
+        "tif"
+      ],
       "description": "File extension without leading dot"
     }
   },

--- a/src/parseo/schemas/copernicus/clms/hrl/waw_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/waw_filename_v0_0_0.json
@@ -4,15 +4,46 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/raster/v1.0.0/schema.json", "https://stac-extensions.github.io/eo/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+  ],
   "description": "CLMS High Resolution Layer Water & Wetness product filename (extension optional).",
   "fields": {
-    "variable": {"type": "string", "enum": ["WAW"], "description": "Product code"},
-    "reference_year": {"type": "string", "pattern": "^\\d{4}$", "description": "Reference year"},
-    "tile_id": {"type": "string", "pattern": "^[EW]\\d{3}[NS]\\d{3}$", "description": "EEA, LAEA reference grid tile identifier"},
-    "resolution": {"type": "string", "pattern": "^(010m|020m|100m)$", "description": "Spatial resolution"},
-    "version": {"type": "string", "pattern": "^V\\d{3}$", "description": "Product version"},
-    "extension": {"type": "string", "enum": ["tif"], "description": "File extension without leading dot"}
+    "variable": {
+      "type": "string",
+      "enum": [
+        "WAW"
+      ],
+      "description": "Product code"
+    },
+    "reference_year": {
+      "type": "string",
+      "pattern": "^\\d{4}$",
+      "description": "Reference year"
+    },
+    "tile_id": {
+      "type": "string",
+      "pattern": "^[EW]\\d{3}[NS]\\d{3}$",
+      "description": "EEA, LAEA reference grid tile identifier"
+    },
+    "resolution": {
+      "type": "string",
+      "pattern": "^(010m|020m|100m)$",
+      "description": "Spatial resolution"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^V\\d{3}$",
+      "description": "Product version"
+    },
+    "extension": {
+      "type": "string",
+      "enum": [
+        "tif"
+      ],
+      "description": "File extension without leading dot"
+    }
   },
   "template": "{variable}_{reference_year}_{tile_id}_{resolution}_{version}[.{extension}]",
   "examples": [

--- a/src/parseo/schemas/copernicus/clms/n2k/n2k_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/n2k/n2k_filename_v1_0_0.json
@@ -9,7 +9,10 @@
   "fields": {
     "theme": {
       "type": "string",
-      "enum": ["N2K", "N2K_Change"],
+      "enum": [
+        "N2K",
+        "N2K_Change"
+      ],
       "description": "Dataset theme"
     },
     "reference": {

--- a/src/parseo/schemas/copernicus/clms/riparian-zones/rpz_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/riparian-zones/rpz_filename_v0_0_0.json
@@ -9,7 +9,9 @@
   "fields": {
     "product": {
       "type": "string",
-      "enum": ["rpz"],
+      "enum": [
+        "rpz"
+      ],
       "description": "Product theme prefix"
     },
     "delivery_unit_id": {
@@ -19,7 +21,9 @@
     },
     "vriable": {
       "type": "string",
-      "enum": ["lclu"],
+      "enum": [
+        "lclu"
+      ],
       "description": "Product abbreviation"
     },
     "reference_years": {
@@ -34,7 +38,9 @@
     },
     "extension": {
       "type": "string",
-      "enum": ["shp"],
+      "enum": [
+        "shp"
+      ],
       "description": "File extension without leading dot"
     }
   },

--- a/src/parseo/schemas/copernicus/clms/urban-atlas/ua_dhm_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/urban-atlas/ua_dhm_filename_v0_0_0.json
@@ -4,7 +4,9 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/vector/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/vector/v1.0.0/schema.json"
+  ],
   "description": "Copernicus Urban Atlas 2021 Digital Height Model (DHM) vector filename schema.",
   "fields": {
     "area_code": {
@@ -19,16 +21,22 @@
     },
     "product": {
       "type": "string",
-      "enum": ["UA"],
+      "enum": [
+        "UA"
+      ],
       "description": "Product code"
     },
     "type": {
       "type": "string",
-      "enum": ["V"],
+      "enum": [
+        "V"
+      ],
       "description": "Data type vector",
       "stac_map": {
         "values": {
-          "V": {"type": "vector"}
+          "V": {
+            "type": "vector"
+          }
         }
       }
     },
@@ -39,20 +47,24 @@
     },
     "variable": {
       "type": "string",
-      "enum": ["DHM"],
+      "enum": [
+        "DHM"
+      ],
       "description": "Product type (Digital Height Model)"
     },
     "extension": {
       "type": "string",
-      "enum": ["shp"],
+      "enum": [
+        "shp"
+      ],
       "description": "Vector file extension without leading dot"
     }
   },
   "template": "{area_code}_{city}_{product}{reference_year}_{variable}[.{extension}]",
   "examples": [
-    "DE074Lx_GÖRLITZ_UA2021_DHM.shp",
-    "DE510Lx_LÜBECK_UA2021_DHM.shp",
-    "DK001Lx_KØBENHAVN_UA2021_DHM.shp",
+    "DE074Lx_G\u00d6RLITZ_UA2021_DHM.shp",
+    "DE510Lx_L\u00dcBECK_UA2021_DHM.shp",
+    "DK001Lx_K\u00d8BENHAVN_UA2021_DHM.shp",
     "ES012Lx_VITORIA_GASTEIZ_UA2021_DHM.shp",
     "ES031Lx_LUGO_UA2021_DHM.shp"
   ]

--- a/src/parseo/schemas/copernicus/clms/urban-atlas/ua_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/urban-atlas/ua_filename_v0_0_0.json
@@ -4,22 +4,34 @@
   "schema_version": "0.0.0",
   "status": "current",
   "stac_version": "1.1.0",
-  "stac_extensions": ["https://stac-extensions.github.io/vector/v1.0.0/schema.json", "https://stac-extensions.github.io/raster/v1.0.0/schema.json"],
+  "stac_extensions": [
+    "https://stac-extensions.github.io/vector/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json"
+  ],
   "description": "Copernicus Urban Atlas filename schema covering status and change layers (extension optional).",
   "fields": {
     "programme": {
       "type": "string",
-      "enum": ["CLMS"],
+      "enum": [
+        "CLMS"
+      ],
       "description": "Constant programme prefix"
     },
     "product": {
       "type": "string",
-      "enum": ["UA"],
+      "enum": [
+        "UA"
+      ],
       "description": "Product code (Urban Atlas)"
     },
     "variable": {
       "type": "string",
-      "enum": ["LCU", "LCUC", "BBH", "GUA"],
+      "enum": [
+        "LCU",
+        "LCUC",
+        "BBH",
+        "GUA"
+      ],
       "description": "Urban Atlas sub-theme identifier"
     },
     "survey": {
@@ -29,12 +41,19 @@
     },
     "type": {
       "type": "string",
-      "enum": ["V","R"],
+      "enum": [
+        "V",
+        "R"
+      ],
       "description": "Data type raster or vector",
       "stac_map": {
         "values": {
-          "V": {"type": "vector"},
-          "R": {"type": "raster"}
+          "V": {
+            "type": "vector"
+          },
+          "R": {
+            "type": "raster"
+          }
         }
       }
     },


### PR DESCRIPTION
## Summary
- pretty-print all Copernicus CLMS schema JSON files to expand single-line field definitions to multiline blocks
- ensure schema arrays and enumerations follow the repository formatting template

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e360b57a18832781fd9a445fabf2fa