### PR TITLE
Add CLI schema selection options for assemble command

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,13 +129,13 @@ The same functionality is exposed through the CLI.
 parseo parse S2B_MSIL2A_20241123T224759_N0511_R101_T03VUL_20241123T230829.SAFE
 
 # Assemble using a JSON document with the required fields
-parseo assemble --family S2 fields.json
+cat fields.json | parseo assemble --family S2 --fields-json -
 
 # Parse a Copernicus Land Monitoring Service (CLMS) filename
 parseo parse ST_20240101T123045_S2_E15N45-01234_010m_V100_PPI.tif
 
 # Assemble the same CLMS filename from key=value pairs
-parseo assemble \
+parseo assemble --family VPP \
   prefix=ST \
   timestamp=20240101T123045 \
   sensor=S2 \

--- a/src/parseo/cli.py
+++ b/src/parseo/cli.py
@@ -10,6 +10,7 @@ from typing import List
 from typing import Union
 
 from parseo import __version__
+from parseo.assembler import assemble
 from parseo.assembler import assemble_auto
 from parseo.parser import describe_schema  # parser helpers
 from parseo.parser import parse_auto
@@ -94,6 +95,14 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     p_asm.add_argument(
         "--fields-json",
         help="JSON string with fields, or '-' to read JSON from stdin.",
+    )
+    p_asm.add_argument(
+        "--family",
+        help="Schema family to use when assembling the filename.",
+    )
+    p_asm.add_argument(
+        "--version",
+        help="Schema version to use (requires --family).",
     )
 
     return ap
@@ -240,7 +249,12 @@ def main(argv: Union[List[str], None] = None) -> int:
 
     if args.cmd == "assemble":
         fields = _resolve_fields(args)
-        out = assemble_auto(fields)
+        if args.version and not args.family:
+            raise SystemExit("--version requires --family to be set.")
+        if args.family:
+            out = assemble(fields, family=args.family, version=args.version)
+        else:
+            out = assemble_auto(fields)
         print(out)
         return 0
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,6 +46,20 @@ def test_cli_assemble_fapar_success(capsys):
     captured = capsys.readouterr()
     assert captured.out.strip() == example
 
+
+def test_cli_assemble_with_family(capsys):
+    example, args = _schema_example_args("S2")
+    assert cli.main(["assemble", "--family", "S2", *args]) == 0
+    captured = capsys.readouterr()
+    assert captured.out.strip() == example
+
+
+def test_cli_assemble_version_requires_family():
+    _, args = _schema_example_args("S2")
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["assemble", "--version", "1.0.0", *args])
+    assert str(exc.value) == "--version requires --family to be set."
+
 def test_fields_json_invalid_string():
     sys.argv = ["parseo", "assemble", "--fields-json", "{"]
     with pytest.raises(SystemExit) as exc:


### PR DESCRIPTION
## Summary
- add optional --family and --version flags to the `parseo assemble` CLI command
- document CLI usage for piping JSON fields and explicit schema selection
- extend CLI tests to cover schema selection and validation behaviour

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e389178db08327bcad65155f0ab2c7