### PR TITLE
docs: expand oneOf example

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,8 @@ Use `oneOf` to express mutually exclusive validation branches for a single field
   "type": "string",
   "oneOf": [
     {"enum": ["A", "B", "C"]},
-    {"pattern": "^X\d{2}$"}
+    {"pattern": "^X\d{2}$"},
+    {"pattern": "^z\d{4}$"}
   ],
   "description": "Legacy letters or experimental codes"
 }


### PR DESCRIPTION
## Summary
- expand the README `oneOf` example to include an additional pattern branch

## Testing
- not run (documentation change)


------
https://chatgpt.com/codex/tasks/task_e_68e3a0586c848327a55b128441002211