### PR TITLE
feat(cli): add list-schemas filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,34 @@ parseo assemble --family VPP \
   extension=tif
 ```
 
+### Discover available schemas
+
+List every schema that ships with parsEO, including the mission family, semantic version, lifecycle status, and file location:
+
+``` bash
+parseo list-schemas
+```
+
+The command prints a table summarizing all discovered schemas, making it easy to confirm which versions are available before parsing or assembling filenames.
+
+List only the schemas that are marked as `current` with the built-in filter (works on every platform):
+
+``` bash
+parseo list-schemas --status current
+```
+
+To inspect a single family in the summary table, provide the family name explicitly:
+
+``` bash
+parseo list-schemas --family S2
+```
+
+For the full schema metadata (fields, examples, etc.), use `schema-info`:
+
+``` bash
+parseo schema-info S2
+```
+
 ### Working with specific schema versions
 
 When multiple schema versions are present, parsEO chooses the one whose `status` is `"current"`. If none are marked current, the highest `schema_version` wins. You can always pin a schema by passing `schema_path` to `assemble` or `parse`.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -93,6 +93,22 @@ def test_cli_list_schemas_outputs_versions(capsys):
     assert entries["S2"][2] == "current"
 
 
+def test_cli_list_schemas_filters_status(capsys):
+    assert cli.main(["list-schemas", "--status", "current"]) == 0
+    lines = capsys.readouterr().out.strip().splitlines()
+    assert lines[0].split() == ["FAMILY", "VERSION", "STATUS", "FILE"]
+    statuses = {line.split(maxsplit=3)[2] for line in lines[1:]}
+    assert statuses == {"current"}
+
+
+def test_cli_list_schemas_filters_family(capsys):
+    assert cli.main(["list-schemas", "--family", "S2"]) == 0
+    lines = capsys.readouterr().out.strip().splitlines()
+    assert lines[0].split() == ["FAMILY", "VERSION", "STATUS", "FILE"]
+    families = {line.split(maxsplit=3)[0] for line in lines[1:]}
+    assert families == {"S2"}
+
+
 def test_cli_schema_info(capsys):
     assert cli.main(["schema-info", "S2"]) == 0
     out = capsys.readouterr().out


### PR DESCRIPTION
## Summary
- add optional --family and --status filters to `parseo list-schemas`
- update the README to document the cross-platform filtering examples
- extend CLI tests to cover the new filtering options

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3a40893c48327acbe708089d1222f