### PR TITLE
feat(cli): expose schema namespace filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,47 @@ parseo assemble --family VPP \
   extension=tif
 ```
 
+### Discover available schemas
+
+List every schema that ships with parsEO, including its fully qualified `schema_id`, semantic version, lifecycle status, and file location:
+
+``` bash
+parseo list-schemas
+```
+
+The command prints a table summarizing all discovered schemas, making it easy to confirm which versions are available before parsing or assembling filenames. The first column shows the complete namespace (for example `copernicus:clms:hrl:vlcc`), so you can see exactly where a product sits inside the Copernicus hierarchy.
+
+List only the schemas that are marked as `current` with the built-in filter (works on every platform):
+
+``` bash
+parseo list-schemas --status current
+```
+
+To inspect a single family in the summary table, provide the short family name explicitly. You can also pass a namespace prefix to see every schema beneath it:
+
+``` bash
+parseo list-schemas --family S2
+parseo list-schemas --family copernicus
+parseo list-schemas --family copernicus:clms:hrl
+```
+
+For the full schema metadata (fields, examples, etc.), use `schema-info`:
+
+``` bash
+parseo schema-info S2
+```
+
+The JSON response includes the schema's semantic version and lifecycle status so
+you can immediately tell which release you are viewing. To inspect an archived
+version, provide the version number explicitly:
+
+``` bash
+parseo schema-info --version 1.0.0 CLC
+```
+
 ### Working with specific schema versions
 
-When multiple schema versions are present, parsEO chooses the one whose `status` is `"current"`. If none are marked current, the highest `schema_version` wins. You can always pin a schema by passing `schema_path` to `assemble` or `parse`.
+When multiple schema versions are present, parsEO chooses the one whose `status` is `"current"`. If none are marked current, the highest `schema_version` wins. You can inspect historical schemas with `parseo schema-info --version <x.y.z> <family>` and you can always pin a schema by passing `schema_path` to `assemble` or `parse`.
 
 ## Authoring new Schema
 

--- a/src/parseo/parser.py
+++ b/src/parseo/parser.py
@@ -211,11 +211,25 @@ def list_schemas(pkg: str = __package__) -> list[str]:
     return list_schema_families(pkg)
 
 
-def describe_schema(family: str, pkg: str = __package__) -> dict[str, Any]:
-    """Return schema metadata and field descriptions for ``family``."""
+def describe_schema(
+    family: str, version: Optional[str] = None, pkg: str = __package__
+) -> dict[str, Any]:
+    """Return schema metadata and field descriptions for ``family``.
+
+    Parameters
+    ----------
+    family:
+        Mission family name (case-insensitive).
+    version:
+        Optional semantic version. When omitted, the schema marked as
+        ``"current"`` for the family is used.
+    pkg:
+        Package that hosts the schemas. Defaults to the installed
+        :mod:`parseo` package.
+    """
 
     try:
-        schema_path = get_schema_path(family, pkg=pkg)
+        schema_path = get_schema_path(family, version=version, pkg=pkg)
     except KeyError as e:
         raise KeyError(str(e))
 
@@ -231,6 +245,8 @@ def describe_schema(family: str, pkg: str = __package__) -> dict[str, Any]:
 
     out: Dict[str, Any] = {
         "schema_id": schema.get("schema_id"),
+        "schema_version": schema.get("schema_version"),
+        "status": schema.get("status"),
         "description": schema.get("description"),
         "fields": fields,
     }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -84,13 +84,48 @@ def test_list_schemas_exposes_known_families():
 def test_cli_list_schemas_outputs_versions(capsys):
     assert cli.main(["list-schemas"]) == 0
     lines = capsys.readouterr().out.strip().splitlines()
-    assert lines[0].split() == ["FAMILY", "VERSION", "STATUS", "FILE"]
+    assert lines[0].split() == ["SCHEMA_ID", "VERSION", "STATUS", "FILE"]
     tokens = [line.split(maxsplit=3) for line in lines[1:]]
     entries = {t[0]: t for t in tokens}
-    assert entries["S1"][1] == "1.0.0"
-    assert entries["S2"][1] == "1.0.0"
-    assert entries["S1"][2] == "current"
-    assert entries["S2"][2] == "current"
+    assert entries["copernicus:sentinel:s1"][1] == "1.0.0"
+    assert entries["copernicus:sentinel:s2"][1] == "1.0.0"
+    assert entries["copernicus:sentinel:s1"][2] == "current"
+    assert entries["copernicus:sentinel:s2"][2] == "current"
+
+
+def test_cli_list_schemas_filters_status(capsys):
+    assert cli.main(["list-schemas", "--status", "current"]) == 0
+    lines = capsys.readouterr().out.strip().splitlines()
+    assert lines[0].split() == ["SCHEMA_ID", "VERSION", "STATUS", "FILE"]
+    statuses = {line.split(maxsplit=3)[2] for line in lines[1:]}
+    assert statuses == {"current"}
+
+
+def test_cli_list_schemas_filters_family(capsys):
+    assert cli.main(["list-schemas", "--family", "S2"]) == 0
+    lines = capsys.readouterr().out.strip().splitlines()
+    assert lines[0].split() == ["SCHEMA_ID", "VERSION", "STATUS", "FILE"]
+    schema_ids = {line.split(maxsplit=3)[0] for line in lines[1:]}
+    assert schema_ids == {"copernicus:sentinel:s2"}
+
+
+def test_cli_list_schemas_filters_prefix(capsys):
+    assert cli.main(["list-schemas", "--family", "copernicus:clms:hrl"]) == 0
+    lines = capsys.readouterr().out.strip().splitlines()
+    assert lines[0].split() == ["SCHEMA_ID", "VERSION", "STATUS", "FILE"]
+    schema_ids = {line.split(maxsplit=3)[0] for line in lines[1:]}
+    assert schema_ids
+    assert all(s.startswith("copernicus:clms:hrl") for s in schema_ids)
+    assert "copernicus:clms:hrl:vlcc" in schema_ids
+
+
+def test_cli_list_schemas_filters_top_level_prefix(capsys):
+    assert cli.main(["list-schemas", "--family", "copernicus"]) == 0
+    lines = capsys.readouterr().out.strip().splitlines()
+    assert lines[0].split() == ["SCHEMA_ID", "VERSION", "STATUS", "FILE"]
+    schema_ids = {line.split(maxsplit=3)[0] for line in lines[1:]}
+    assert schema_ids
+    assert all(s.startswith("copernicus") for s in schema_ids)
 
 
 def test_cli_schema_info(capsys):
@@ -98,12 +133,23 @@ def test_cli_schema_info(capsys):
     out = capsys.readouterr().out
     data = json.loads(out)
     assert data["schema_id"] == "copernicus:sentinel:s2"
+    assert data["schema_version"] == "1.0.0"
+    assert data["status"] == "current"
     assert "platform" in data["fields"]
     assert data["fields"]["platform"]["description"] == "Spacecraft unit"
     assert isinstance(data.get("template"), str)
     assert isinstance(data.get("examples"), list)
     assert data["examples"]
     assert all(isinstance(x, str) for x in data["examples"])
+
+
+def test_cli_schema_info_specific_version(capsys):
+    assert cli.main(["schema-info", "--version", "1.0.0", "CLC"]) == 0
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["schema_id"] == "copernicus:clms:clc"
+    assert data["schema_version"] == "1.0.0"
+    assert data["status"] == "deprecated"
 
 def test_cli_stac_sample_custom_url(monkeypatch, capsys):
     calls = {}


### PR DESCRIPTION
## Summary
- show fully qualified schema identifiers in the `parseo list-schemas` output
- add namespace-aware filtering so prefixes like `copernicus` or `copernicus:clms:hrl` work cross-platform
- persist schema identifiers in the registry and document the new CLI workflow

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3a40893c48327acbe708089d1222f