### PR TITLE
Allow schema IDs to be used as family names

### DIFF
--- a/src/parseo/schema_registry.py
+++ b/src/parseo/schema_registry.py
@@ -28,6 +28,8 @@ _FAMILY_SYNONYMS: Dict[str, str] = {v: k for k, v in _FAMILY_ALIASES.items()}
 
 def _normalize_family_name(family: str) -> str:
     fam = family.upper()
+    if ":" in fam:
+        fam = fam.split(":")[-1]
     return _FAMILY_SYNONYMS.get(fam, fam)
 
 


### PR DESCRIPTION
## Summary
- allow schema registry to strip schema ID prefixes when normalizing family names so colon-delimited identifiers resolve

## Testing
- ruff check . *(fails: existing duplicate test definitions trigger F811 in tests/test_cli.py)*
- pytest *(fails: existing expectations for list-schemas headers in tests/test_cli.py)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ae3464e083279922458e5ebeabcf