### PR TITLE
Add CLI flag to write parse output to a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ cat fields.json | parseo assemble --family S2 --fields-json -
 # Parse a Copernicus Land Monitoring Service (CLMS) filename
 parseo parse ST_20240101T123045_S2_E15N45-03035-010m_V100_PPI.tif
 
+# Parse and write the JSON response to a file
+parseo parse ST_20240101T123045_S2_E15N45-03035-010m_V100_PPI.tif --output result.json
+
 # Assemble the same CLMS filename from key=value pairs
 parseo assemble --family VPP \
   prefix=ST \

--- a/src/parseo/cli.py
+++ b/src/parseo/cli.py
@@ -35,6 +35,10 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     # parse
     p_parse = sp.add_parser("parse", help="Parse a filename")
     p_parse.add_argument("filename")
+    p_parse.add_argument(
+        "--output",
+        help="Write the JSON result to this file instead of stdout. Use '-' for stdout.",
+    )
 
     # list-schemas
     p_list = sp.add_parser("list-schemas", help="List available schema families")
@@ -215,7 +219,15 @@ def main(argv: Union[List[str], None] = None) -> int:
         mfam = getattr(res, "match_family", None)
         if mfam:
             out["match_family"] = mfam
-        print(json.dumps(out, indent=2, ensure_ascii=False))
+        payload = json.dumps(out, indent=2, ensure_ascii=False)
+        if args.output and args.output != "-":
+            try:
+                with open(args.output, "w", encoding="utf-8") as fh:
+                    fh.write(f"{payload}\n")
+            except OSError as exc:
+                raise SystemExit(f"Failed to write to '{args.output}': {exc}") from exc
+        else:
+            print(payload)
         return 0
 
     if args.cmd == "list-schemas":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,6 +18,17 @@ def _schema_example_args(family: str) -> tuple[str, list[str]]:
     return example, args
 
 
+def test_cli_parse_writes_output_file(tmp_path, capsys):
+    example, _ = _schema_example_args("S2")
+    target = tmp_path / "result.json"
+    assert cli.main(["parse", example, "--output", str(target)]) == 0
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    data = json.loads(target.read_text(encoding="utf-8"))
+    assert data["valid"] is True
+    assert data["fields"] == parse_auto(example).fields
+
+
 def test_cli_reports_version(capsys):
     with pytest.raises(SystemExit) as exc:
         cli.main(["--version"])


### PR DESCRIPTION
## Summary
- add a `--output` option to `parseo parse` so results can be written directly to disk
- document the new flag in the README and cover it with a CLI regression test

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3b59df7ac832792801f23218b431b