### PR TITLE
Document assembling CLMS filenames from JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,12 @@ parseo parse ST_20240101T123045_S2_E15N45-03035-010m_V100_PPI.tif
 # Parse and write the JSON response to a file
 parseo parse ST_20240101T123045_S2_E15N45-03035-010m_V100_PPI.tif --output result.json
 
+# Assemble from the saved JSON document
+cat result.json | parseo assemble --family copernicus:clms:hr-vpp:st --fields-json -
+
 # Assemble the same CLMS filename from key=value pairs
 parseo assemble
-  product=ST 
+  product=ST
   timestamp=20240101T123045 
   sensor=S2
   tile_id=E15N45


### PR DESCRIPTION
## Summary
- add a CLI example that reassembles a CLMS filename using the JSON saved by `parseo parse`

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3b9596bf8832797dcc5e8e084f876