### PR TITLE
Add schema-aware CLI parsing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ The same functionality is exposed through the CLI.
 # Parse a filename
 parseo parse S2B_MSIL2A_20241123T224759_N0511_R101_T03VUL_20241123T230829.SAFE
 
+# Parse a filename with an explicit schema
+parseo parse --schema src/parseo/schemas/copernicus/sentinel/s2/s2_filename_v1_0_0.json \
+  S2B_MSIL2A_20241123T224759_N0511_R101_T03VUL_20241123T230829.SAFE
+
 # Assemble using a JSON document with the required fields
 cat fields.json | parseo assemble --family S2 --fields-json -
 

--- a/src/parseo/__init__.py
+++ b/src/parseo/__init__.py
@@ -4,6 +4,7 @@ from importlib import metadata
 from .assembler import assemble
 from .assembler import assemble_auto
 from .assembler import clear_schema_cache
+from .parser import parse
 from .parser import parse_auto
 from .parser import validate_schema
 from .schema_registry import get_schema_path
@@ -35,6 +36,7 @@ def info() -> dict[str, str]:
 
 
 __all__ = [
+    "parse",
     "parse_auto",
     "assemble",
     "assemble_auto",

--- a/src/parseo/cli.py
+++ b/src/parseo/cli.py
@@ -14,6 +14,7 @@ from parseo.assembler import assemble
 from parseo.assembler import assemble_auto
 from parseo.parser import ParseError
 from parseo.parser import describe_schema  # parser helpers
+from parseo.parser import parse
 from parseo.parser import parse_auto
 from parseo.schema_registry import discover_families
 from parseo.stac_http import list_collections_http
@@ -38,6 +39,10 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     p_parse.add_argument(
         "--output",
         help="Write the JSON result to this file instead of stdout. Use '-' for stdout.",
+    )
+    p_parse.add_argument(
+        "--schema",
+        help="Path to a schema JSON file to parse with instead of auto-detection.",
     )
 
     # list-schemas
@@ -214,7 +219,10 @@ def main(argv: Union[List[str], None] = None) -> int:
 
     if args.cmd == "parse":
         try:
-            res = parse_auto(args.filename)
+            if args.schema:
+                res = parse(args.filename, schema_path=args.schema)
+            else:
+                res = parse_auto(args.filename)
         except ParseError as exc:
             hint = ""
             family = getattr(exc, "match_family", None)


### PR DESCRIPTION
## Summary
- add a dedicated `parse` helper that can target a specific schema and expose it through the CLI
- document CLI usage for schema-pinned parsing and expand parser tests

## Testing
- ruff check .
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3e0a664048327b9934642b552ad46