### PR TITLE
Update tile_id schema definitions for LAEA and MGRS grids

### DIFF
--- a/src/parseo/schemas/copernicus/clms/clcplus/ras/clcplus_filename_v0_0_1.json
+++ b/src/parseo/schemas/copernicus/clms/clcplus/ras/clcplus_filename_v0_0_1.json
@@ -49,9 +49,10 @@
       "description": "Spatial resolution expressed with leading 'R' and units"
     },
     "tile_id": {
+      "title": "INSPIRE ETRS89-LAEA Grid",
       "type": "string",
-      "pattern": "^[EW]\\d{2}[NS]\\d{2}$",
-      "description": "Tile identifier in the EEA 10m grid (easting/northing)"
+      "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+      "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
     },
     "epsg_code": {
       "type": "string",

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/st_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/st_filename_v0_0_0.json
@@ -30,17 +30,19 @@
       "description": "Sensor platform"
     },
     "tile_id": {
-      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "description": "Regional LAEA grid tile or MGRS tile identifier",
       "oneOf": [
         {
+          "title": "INSPIRE ETRS89-LAEA Grid",
           "type": "string",
           "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
           "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
         },
         {
+          "title": "MGRS",
           "type": "string",
           "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
-          "description": "Sentinel-2 MGRS tile identifier"
+          "description": "MGRS tile identifier (as used by Sentinel-2 products)"
         }
       ]
     },

--- a/src/parseo/schemas/copernicus/clms/hr-vpp/vi_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-vpp/vi_filename_v0_0_0.json
@@ -44,9 +44,10 @@
       "description": "Spatial resolution of the raster"
     },
     "tile_id": {
+      "title": "MGRS",
       "type": "string",
       "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
-      "description": "MGRS tile identifier"
+      "description": "MGRS tile identifier (as used by Sentinel-2 products)"
     },
     "start_date": {
       "type": "string",

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/cc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/cc_filename_v0_0_0.json
@@ -39,9 +39,10 @@
       "description": "Pixel spacing"
     },
     "tile_id": {
+      "title": "MGRS",
       "type": "string",
       "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
-      "description": "MGRS tile identifier"
+      "description": "MGRS tile identifier (as used by Sentinel-2 products)"
     },
     "sensing_datetime": {
       "type": "string",

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/fsc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/fsc_filename_v0_0_0.json
@@ -39,9 +39,10 @@
       "description": "Pixel spacing"
     },
     "tile_id": {
+      "title": "MGRS",
       "type": "string",
       "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
-      "description": "MGRS tile identifier"
+      "description": "MGRS tile identifier (as used by Sentinel-2 products)"
     },
     "sensing_datetime": {
       "type": "string",

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/gfsc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/gfsc_filename_v0_0_0.json
@@ -39,9 +39,10 @@
       "description": "Pixel spacing"
     },
     "tile_id": {
+      "title": "MGRS",
       "type": "string",
       "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
-      "description": "MGRS tile identifier"
+      "description": "MGRS tile identifier (as used by Sentinel-2 products)"
     },
     "period": {
       "type": "string",

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/icd_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/icd_filename_v0_0_0.json
@@ -40,17 +40,19 @@
       "description": "Pixel spacing"
     },
     "tile_id": {
-      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "description": "Regional LAEA grid tile or MGRS tile identifier",
       "oneOf": [
         {
+          "title": "INSPIRE ETRS89-LAEA Grid",
           "type": "string",
           "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
           "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
         },
         {
+          "title": "MGRS",
           "type": "string",
           "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
-          "description": "Sentinel-2 MGRS tile identifier"
+          "description": "MGRS tile identifier (as used by Sentinel-2 products)"
         }
       ]
     },

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/sp_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/sp_filename_v0_0_0.json
@@ -41,17 +41,19 @@
       "description": "Pixel spacing"
     },
     "tile_id": {
-      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "description": "Regional LAEA grid tile or MGRS tile identifier",
       "oneOf": [
         {
+          "title": "INSPIRE ETRS89-LAEA Grid",
           "type": "string",
           "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
           "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
         },
         {
+          "title": "MGRS",
           "type": "string",
           "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
-          "description": "Sentinel-2 MGRS tile identifier"
+          "description": "MGRS tile identifier (as used by Sentinel-2 products)"
         }
       ]
     },

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/sws_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/sws_filename_v0_0_0.json
@@ -39,9 +39,10 @@
       "description": "Pixel spacing"
     },
     "tile_id": {
+      "title": "MGRS",
       "type": "string",
       "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
-      "description": "MGRS tile identifier"
+      "description": "MGRS tile identifier (as used by Sentinel-2 products)"
     },
     "sensing_datetime": {
       "type": "string",

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/wcd_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/wcd_filename_v0_0_0.json
@@ -41,17 +41,19 @@
       "description": "Pixel spacing"
     },
     "tile_id": {
-      "description": "Regional LAEA grid tile or Sentinel-2 MGRS tile identifier (2- or 3-digit coordinates)",
+      "description": "Regional LAEA grid tile or MGRS tile identifier",
       "oneOf": [
         {
+          "title": "INSPIRE ETRS89-LAEA Grid",
           "type": "string",
           "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
           "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
         },
         {
+          "title": "MGRS",
           "type": "string",
           "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
-          "description": "Sentinel-2 MGRS tile identifier"
+          "description": "MGRS tile identifier (as used by Sentinel-2 products)"
         }
       ]
     },

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/wds_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/wds_filename_v0_0_0.json
@@ -39,9 +39,10 @@
       "description": "Pixel spacing"
     },
     "tile_id": {
+      "title": "MGRS",
       "type": "string",
       "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
-      "description": "MGRS tile identifier"
+      "description": "MGRS tile identifier (as used by Sentinel-2 products)"
     },
     "sensing_datetime": {
       "type": "string",

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/wic_comb_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/wic_comb_filename_v0_0_0.json
@@ -39,9 +39,10 @@
       "description": "Pixel spacing"
     },
     "tile_id": {
+      "title": "MGRS",
       "type": "string",
       "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
-      "description": "MGRS tile identifier"
+      "description": "MGRS tile identifier (as used by Sentinel-2 products)"
     },
     "period_start": {
       "type": "string",

--- a/src/parseo/schemas/copernicus/clms/hr-wsi/wic_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hr-wsi/wic_filename_v0_0_0.json
@@ -40,9 +40,10 @@
       "description": "Pixel spacing"
     },
     "tile_id": {
+      "title": "MGRS",
       "type": "string",
       "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
-      "description": "MGRS tile identifier"
+      "description": "MGRS tile identifier (as used by Sentinel-2 products)"
     },
     "sensing_datetime": {
       "type": "string",

--- a/src/parseo/schemas/copernicus/clms/hrl/fty_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/fty_filename_v0_0_0.json
@@ -23,9 +23,10 @@
       "description": "Reference year"
     },
     "tile_id": {
+      "title": "INSPIRE ETRS89-LAEA Grid",
       "type": "string",
-      "pattern": "^[EW]\\d{3}[NS]\\d{3}$",
-      "description": "EEA, LAEA reference grid tile identifier"
+      "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+      "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
     },
     "resolution": {
       "type": "string",

--- a/src/parseo/schemas/copernicus/clms/hrl/gra_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/gra_filename_v0_0_0.json
@@ -23,9 +23,10 @@
       "description": "Reference year"
     },
     "tile_id": {
+      "title": "INSPIRE ETRS89-LAEA Grid",
       "type": "string",
-      "pattern": "^[EW]\\d{3}[NS]\\d{3}$",
-      "description": "EEA, LAEA reference grid tile identifier"
+      "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+      "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
     },
     "resolution": {
       "type": "string",

--- a/src/parseo/schemas/copernicus/clms/hrl/ibu_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/ibu_filename_v0_0_0.json
@@ -28,9 +28,10 @@
       "description": "Spatial resolution in metres with leading zeros"
     },
     "tile_id": {
+      "title": "INSPIRE ETRS89-LAEA Grid",
       "type": "string",
       "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
-      "description": "EEA reference grid tile identifier"
+      "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
     },
     "epsg_code": {
       "type": "string",

--- a/src/parseo/schemas/copernicus/clms/hrl/imp_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/imp_filename_v0_0_0.json
@@ -23,9 +23,10 @@
       "description": "Reference year"
     },
     "tile_id": {
+      "title": "INSPIRE ETRS89-LAEA Grid",
       "type": "string",
-      "pattern": "^[EW]\\d{3}[NS]\\d{3}$",
-      "description": "EEA, LAEA reference grid tile identifier"
+      "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+      "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
     },
     "resolution": {
       "type": "string",

--- a/src/parseo/schemas/copernicus/clms/hrl/nvlcc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/nvlcc_filename_v0_0_0.json
@@ -40,9 +40,10 @@
       "description": "Spatial resolution"
     },
     "tile_id": {
+      "title": "INSPIRE ETRS89-LAEA Grid",
       "type": "string",
-      "pattern": "^[EW]\\d{2}[NS]\\d{2}$",
-      "description": "Tile identifier in the EEA 10m grid (easting/northing)"
+      "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+      "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
     },
     "epsg_code": {
       "type": "string",

--- a/src/parseo/schemas/copernicus/clms/hrl/swf_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/swf_filename_v0_0_0.json
@@ -23,9 +23,10 @@
       "description": "Reference year"
     },
     "tile_id": {
+      "title": "INSPIRE ETRS89-LAEA Grid",
       "type": "string",
-      "pattern": "^[EW]\\d{3}[NS]\\d{3}$",
-      "description": "EEA, LAEA reference grid tile identifier"
+      "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+      "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
     },
     "resolution": {
       "type": "string",

--- a/src/parseo/schemas/copernicus/clms/hrl/swf_filename_v0_0_1.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/swf_filename_v0_0_1.json
@@ -28,9 +28,10 @@
       "description": "Spatial resolution"
     },
     "tile_id": {
+      "title": "INSPIRE ETRS89-LAEA Grid",
       "type": "string",
       "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
-      "description": "EEA reference grid tile identifier"
+      "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
     },
     "epsg_code": {
       "type": "string",

--- a/src/parseo/schemas/copernicus/clms/hrl/tcd_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/tcd_filename_v0_0_0.json
@@ -23,9 +23,10 @@
       "description": "Reference year"
     },
     "tile_id": {
+      "title": "INSPIRE ETRS89-LAEA Grid",
       "type": "string",
-      "pattern": "^[EW]\\d{3}[NS]\\d{3}$",
-      "description": "EEA, LAEA reference grid tile identifier"
+      "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+      "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
     },
     "resolution": {
       "type": "string",

--- a/src/parseo/schemas/copernicus/clms/hrl/vlcc_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/vlcc_filename_v0_0_0.json
@@ -47,9 +47,21 @@
       "description": "Spatial resolution"
     },
     "tile_id": {
-      "type": "string",
-      "pattern": "^(?:[EW]\\d{2}[NS]\\d{2}|[A-Z]{2})$",
-      "description": "Tile identifier in the EEA 10m grid (easting/northing) or two-letter geographic code"
+      "description": "Tile identifier in the EEA 10m grid (easting/northing) or two-letter geographic code",
+      "oneOf": [
+        {
+          "title": "INSPIRE ETRS89-LAEA Grid",
+          "type": "string",
+          "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+          "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
+        },
+        {
+          "title": "Geographic code",
+          "type": "string",
+          "pattern": "^[A-Z]{2}$",
+          "description": "Two-letter geographic code used by VLCC vector products"
+        }
+      ]
     },
     "epsg_code": {
       "type": "string",

--- a/src/parseo/schemas/copernicus/clms/hrl/waw_filename_v0_0_0.json
+++ b/src/parseo/schemas/copernicus/clms/hrl/waw_filename_v0_0_0.json
@@ -23,9 +23,10 @@
       "description": "Reference year"
     },
     "tile_id": {
+      "title": "INSPIRE ETRS89-LAEA Grid",
       "type": "string",
-      "pattern": "^[EW]\\d{3}[NS]\\d{3}$",
-      "description": "EEA, LAEA reference grid tile identifier"
+      "pattern": "^[EW]\\d{2,3}[NS]\\d{2,3}$",
+      "description": "Regional LAEA grid tile identifier (2- or 3-digit coordinates)"
     },
     "resolution": {
       "type": "string",

--- a/src/parseo/schemas/copernicus/sentinel/s2_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s2_filename_v1_0_0.json
@@ -38,9 +38,10 @@
       "description": "Relative orbit number"
     },
     "tile_id": {
+      "title": "MGRS",
       "type": "string",
-      "pattern": "^T\\d{2}[A-Z]{3}$",
-      "description": "MGRS tile identifier"
+      "pattern": "^T\\d{2}[C-HJ-NP-X][A-Z]{2}$",
+      "description": "MGRS tile identifier (as used by Sentinel-2 products)"
     },
     "generation_datetime": {
       "type": "string",


### PR DESCRIPTION
## Summary
- add explicit titles and corrected regex patterns for MGRS tile identifiers across Sentinel-2 and HR-WSI schemas
- normalize LAEA grid tile definitions to accept 2- or 3-digit coordinates and reuse the INSPIRE wording across HRL and CLC+ schemas
- align mixed tile_id rules with shared oneOf blocks, including VLCC two-letter codes alongside LAEA tiles

## Testing
- ruff check .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e406f064a88327b8e19a7581eefd05