### PR TITLE
Sentinel-1 schema: add COG option, fix abs_orbit and datatake

### DIFF
--- a/src/parseo/schemas/copernicus/sentinel/s1_filename_v1_0_0.json
+++ b/src/parseo/schemas/copernicus/sentinel/s1_filename_v1_0_0.json
@@ -48,12 +48,12 @@
     },
     "abs_orbit": {
       "type": "string",
-      "pattern": "^A\\d{6}$",
+      "pattern": "^A?\\d{6}$",
       "description": "Absolute orbit number"
     },
     "datatake": {
       "type": "string",
-      "pattern": "^D[0-9A-F]{6}$",
+      "pattern": "^D?[0-9A-F]{6}$",
       "description": "Datatake ID"
     },
     "product_id": {
@@ -61,18 +61,24 @@
       "pattern": "^[0-9A-F]{4,12}$",
       "description": "Unique product ID"
     },
+    "cog":{
+      "type": "string",
+      "enum": ["COG"],
+      "description": "COG extension without leading hyphen"
+    },
     "extension": {
       "type": "string",
       "enum": ["SAFE"],
       "description": "File extension without leading dot"
     }
   },
-  "template": "{platform}_{instrument_mode}_{product_type}_{processing_level}{product_class}{polarization}_{start_datetime}_{end_datetime}_{abs_orbit}_{datatake}_{product_id}[.{extension}]",
+  "template": "{platform}_{instrument_mode}_{product_type}_{processing_level}{product_class}{polarization}_{start_datetime}_{end_datetime}_{abs_orbit}_{datatake}_{product_id}[_{cog}][.{extension}]",
   "examples": [
     "S1A_IW_SLC__1SDV_20250105T053021_20250105T053048_A054321_D068F2E_ABC123.SAFE",
     "S1B_EW_GRDH_1SDH_20190101T000000_20190101T000030_A012345_D0ABCDE_ABCDEF",
     "S1C_SM_OCN__1SSV_20240701T101010_20240701T101111_A123456_D1A2B3C_1A2B3C.SAFE",
     "S1A_EW_RAW__0SDV_20230601T123456_20230601T123546_A210987_D0ABCDE_123ABC.SAFE",
-    "S1B_SM_GRDE_1SDV_20190315T120000_20190315T120030_A654321_D0FEDCB_DEF123"
+    "S1B_SM_GRDE_1SDV_20190315T120000_20190315T120030_A654321_D0FEDCB_DEF123",
+    "S1C_IW_GRDH_1SDH_20250624T095150_20250624T095215_002923_005F96_9FA1_COG.SAFE"
   ]
 }


### PR DESCRIPTION
This PR:

* enables parsing of filenames containing a COG (cloud-optimised GeoTIFF) designation
* Makes the `A`(bsolute) and `D`(atatake) signifiers optional - these were previously mandatory
* Adds an example filename with these options.

Note that https://sentiwiki.copernicus.eu/web/s1-products#SAR-Naming-Convention makes no mention of the `A` and `D` signifiers. I'm therefore not sure why these are included in the scheme.

This PR originates from my attempts to parse the filenames of tiles in the metadata payload returned by the SentinelHub Process API (see https://sentinelhub-py.readthedocs.io/en/latest/examples/process_request.html#Example-6-:-Multi-response-request-type). Here is an example payload:

```
{'scenes': [{'dateFrom': '2025-06-24T00:00:00Z',
   'dateTo': '2025-06-24T23:59:59Z',
   'tiles': [{'shId': 3430857,
     'date': '2025-06-24T09:51:50Z',
     'dataPath': 'creo://eodata/Sentinel-1/SAR/IW_GRDH_1S-COG/2025/06/24/S1C_IW_GRDH_1SDH_20250624T095150_20250624T095215_002923_005F96_9FA1_COG.SAFE',
     'sentinel1ProductId': 'S1C_IW_GRDH_1SDH_20250624T095150_20250624T095215_002923_005F96_9FA1_COG.SAFE'}],
   '__idx': 0}]}
```

